### PR TITLE
Improved keyword searching on database names

### DIFF
--- a/dbdb/core/management/commands/generate_searchtext.py
+++ b/dbdb/core/management/commands/generate_searchtext.py
@@ -5,17 +5,29 @@ from dbdb.core.models import SystemVersion
 
 class Command(BaseCommand):
 
-    def handle(self, *args, **options):
-        SystemSearchText.objects.all().delete()
+    def add_arguments(self, parser):
+        parser.add_argument('system', metavar='S', type=str, nargs='?',
+                    help='System to force search text genration')
+        return
 
-        for s in SystemVersion.objects.filter(is_current=True).order_by("-id"):
+    def handle(self, *args, **options):
+
+        versions = SystemVersion.objects.filter(is_current=True)
+        if options['system']:
+            keyword = options['system']
+            if keyword.isdigit():
+                versions = versions.filter(system__id=int(keyword))
+            else:
+                versions = versions.filter(system__name__icontains=keyword)
+
+        for s in versions.order_by("system__name"):
+            sstext, created = SystemSearchText.objects.update_or_create(system=s.system)
             try:
-                sstext = SystemSearchText()
                 sstext.system = s.system
                 sstext.name = s.system.name
                 sstext.search_text = s.generate_searchtext()
                 sstext.save()
-                print("Created", s.system)
+                print("Added search text for %s [id=%d]" % (s.system.name, s.system.id))
             except:
                 print("Failed", s.system)
                 raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ cairosvg==2.7.0
 gunicorn==20.1.0
 psycopg2-binary==2.9.5
 filelock==3.8.0
+anyascii==0.3.2


### PR DESCRIPTION
* Automatically convert non-ascii names to ascii characters
* Automatically generate name variations with/without common suffixes (e.g., MongoDB→Mongo, Kuzu→KuzuDB)