### PR TITLE
Fix dead/spam CitationUrl assignment in enrichment commands; refactor…

### DIFF
--- a/dbdb/core/management/commands/enrich_organization.py
+++ b/dbdb/core/management/commands/enrich_organization.py
@@ -346,8 +346,11 @@ class Command(EnricherBaseCommand):
                     norm = normalize_url(url_str)
                     existing = CitationUrl.objects.filter(url=norm).first()
                     if existing:
-                        setattr(org, field, existing)
-                        dirty = True
+                        if existing.status in (CitationUrl.Status.DEAD, CitationUrl.Status.SPAM):
+                            LOG.warning(f"  {field}: existing citation {url_str!r} has status {CitationUrl.Status(existing.status).name}, skipping")
+                        else:
+                            setattr(org, field, existing)
+                            dirty = True
                         continue
                     citation = CitationUrl.objects.create(url=norm, status=CitationUrl.Status.UNKNOWN)
                     citation, info = process_citation_url(citation, skip_spamcheck=options['skip_spamcheck'])
@@ -502,7 +505,11 @@ class Command(EnricherBaseCommand):
                     norm = normalize_url(linkedin_url)
                     existing = CitationUrl.objects.filter(url=norm).first()
                     if existing:
-                        citation = existing
+                        if existing.status in (CitationUrl.Status.DEAD, CitationUrl.Status.SPAM):
+                            LOG.warning("linkedin_url: %r has status %s, skipping", linkedin_url, CitationUrl.Status(existing.status).name)
+                            citation = None
+                        else:
+                            citation = existing
                     else:
                         citation = CitationUrl.objects.create(url=norm, status=CitationUrl.Status.UNKNOWN)
                         citation, info = process_citation_url(citation, skip_spamcheck=options['skip_spamcheck'])

--- a/dbdb/core/management/commands/enrich_organization.py
+++ b/dbdb/core/management/commands/enrich_organization.py
@@ -14,6 +14,7 @@ For each empty field on the Organization, the command:
 import logging
 import re
 import time
+from urllib.parse import urljoin
 from argparse import ArgumentParser
 from datetime import timedelta
 
@@ -506,6 +507,8 @@ class Command(EnricherBaseCommand):
             if validator is None:
                 continue
             raw = result.get(field) or ''
+            if raw and not raw.startswith(('http://', 'https://')):
+                raw = urljoin(org.url.url, raw)
             validated = validator(raw)
             if not validated:
                 LOG.warning("Skipping '%s': extracted %s is invalid: %r", org.slug, field, raw)

--- a/dbdb/core/management/commands/enrich_organization.py
+++ b/dbdb/core/management/commands/enrich_organization.py
@@ -258,6 +258,7 @@ class Command(EnricherBaseCommand):
                 time.sleep(sleep_secs)
             did_work = False
             try:
+                org.refresh_from_db()
                 if do_enrich:
                     did_work |= self._enrich_one(org, options)
                 if do_extract_urls:
@@ -271,8 +272,6 @@ class Command(EnricherBaseCommand):
             prev_did_work = did_work
 
     def _enrich_one(self, org: Organization, options: dict) -> bool:
-        org.refresh_from_db()
-
         dry_run: bool    = options['dry_run']
         model_override   = options['model']
         include_urls     = options['include_urls']
@@ -436,7 +435,6 @@ class Command(EnricherBaseCommand):
         return True
 
     def _extract_urls_one(self, org: Organization, options: dict, *, enricher=None) -> bool:
-        org.refresh_from_db()
         dry_run: bool = options['dry_run']
 
         if org.url_id is None:

--- a/dbdb/core/management/commands/enrich_organization.py
+++ b/dbdb/core/management/commands/enrich_organization.py
@@ -157,6 +157,13 @@ def _validate_crunchbase_url(url: str) -> str | None:
     return None
 
 
+# Maps each extractable URL field to its format validator.
+_URL_FIELD_VALIDATORS = {
+    'linkedin_url': _validate_linkedin_url,
+    'crunchbase_url': _validate_crunchbase_url,
+}
+
+
 def _crawl_org_urls(org: Organization, recrawl_after: int = 7, skip_spamcheck: bool = False) -> dict[str, str]:
     """Crawl the org's CitationUrl FK fields; return {url: text_excerpt}."""
     crawled: dict[str, str] = {}
@@ -436,7 +443,7 @@ class Command(EnricherBaseCommand):
             return False
 
         if org.url.status in (CitationUrl.Status.DEAD, CitationUrl.Status.SPAM):
-            LOG.info("Skipping '%s': url status is %s", org.slug, org.url.status.name)
+            LOG.info("Skipping '%s': url status is %s", org.slug, CitationUrl.Status(org.url.status).name)
             return False
 
         url_fields = ['linkedin_url', 'crunchbase_url']
@@ -490,59 +497,42 @@ class Command(EnricherBaseCommand):
                 break
 
         if dry_run:
-            self.stdout.write(
-                f"  [DRY RUN] linkedin_url={result.get('linkedin_url')!r}, "
-                f"crunchbase_url={result.get('crunchbase_url')!r}"
-            )
+            parts = [f"{f}={result.get(f)!r}" for f in ('linkedin_url', 'crunchbase_url')]
+            self.stdout.write(f"  [DRY RUN] {', '.join(parts)}")
             return True
 
-        if 'linkedin_url' in missing:
-            linkedin_url = _validate_linkedin_url(result.get('linkedin_url') or '')
-            if not linkedin_url:
-                LOG.warning("Skipping '%s': extracted linkedin_url is invalid: %r", org.slug, result.get('linkedin_url'))
-            else:
-                try:
-                    norm = normalize_url(linkedin_url)
-                    existing = CitationUrl.objects.filter(url=norm).first()
-                    if existing:
-                        if existing.status in (CitationUrl.Status.DEAD, CitationUrl.Status.SPAM):
-                            LOG.warning("linkedin_url: %r has status %s, skipping", linkedin_url, CitationUrl.Status(existing.status).name)
-                            citation = None
-                        else:
-                            citation = existing
+        for field in missing:
+            validator = _URL_FIELD_VALIDATORS.get(field)
+            if validator is None:
+                continue
+            raw = result.get(field) or ''
+            validated = validator(raw)
+            if not validated:
+                LOG.warning("Skipping '%s': extracted %s is invalid: %r", org.slug, field, raw)
+                continue
+            try:
+                norm = normalize_url(validated)
+                existing = CitationUrl.objects.filter(url=norm).first()
+                if existing:
+                    if existing.status in (CitationUrl.Status.DEAD, CitationUrl.Status.SPAM):
+                        LOG.warning("%s: %r has status %s, skipping", field, validated, CitationUrl.Status(existing.status).name)
+                        continue
+                    citation = existing
+                else:
+                    citation = CitationUrl.objects.create(url=norm, status=CitationUrl.Status.UNKNOWN)
+                    citation, info = process_citation_url(citation, skip_spamcheck=options['skip_spamcheck'])
+                    if info is None:
+                        pass  # merged into an existing CitationUrl
+                    elif info['status'] in (CitationUrl.Status.VALID, CitationUrl.Status.IGNORE):
+                        citation.save()
                     else:
-                        citation = CitationUrl.objects.create(url=norm, status=CitationUrl.Status.UNKNOWN)
-                        citation, info = process_citation_url(citation, skip_spamcheck=options['skip_spamcheck'])
-                        if info is not None and info['status'] != CitationUrl.Status.VALID:
-                            LOG.warning("linkedin_url: %r is unreachable, skipping", linkedin_url)
-                            citation.delete()
-                            citation = None
-                        elif info is not None:
-                            citation.save()
-                    if citation is not None:
-                        org.linkedin_url = citation
-                        org.save(update_fields=['linkedin_url'])
-                        self.stdout.write(self.style.SUCCESS(f"  Set linkedin_url={linkedin_url} for '{org.name}'"))
-                except Exception as e:
-                    LOG.warning("linkedin_url: could not validate %r: %s", linkedin_url, e)
-
-        if 'crunchbase_url' in missing:
-            # crunchbase.com is in SKIP_DOMAINS so process_citation_url returns IGNORE.
-            # Validate URL format only; get-or-create the CitationUrl without HTTP fetch.
-            crunchbase_url = _validate_crunchbase_url(result.get('crunchbase_url') or '')
-            if not crunchbase_url:
-                LOG.warning("Skipping '%s': extracted crunchbase_url is invalid: %r", org.slug, result.get('crunchbase_url'))
-            else:
-                try:
-                    norm = normalize_url(crunchbase_url)
-                    citation, created = CitationUrl.objects.get_or_create(
-                        url=norm,
-                        defaults={'status': CitationUrl.Status.IGNORE},
-                    )
-                    org.crunchbase_url = citation
-                    org.save(update_fields=['crunchbase_url'])
-                    self.stdout.write(self.style.SUCCESS(f"  Set crunchbase_url={crunchbase_url} for '{org.name}'"))
-                except Exception as e:
-                    LOG.warning("crunchbase_url: could not save %r: %s", crunchbase_url, e)
+                        LOG.warning("%s: %r is unreachable, skipping", field, validated)
+                        citation.delete()
+                        continue
+                setattr(org, field, citation)
+                org.save(update_fields=[field])
+                self.stdout.write(self.style.SUCCESS(f"  Set {field}={validated} for '{org.name}'"))
+            except Exception as e:
+                LOG.warning("%s: could not save %r: %s", field, validated, e)
 
         return True

--- a/dbdb/core/management/commands/enrich_system.py
+++ b/dbdb/core/management/commands/enrich_system.py
@@ -15,6 +15,7 @@ import logging
 import re
 import sys
 import time
+from urllib.parse import urljoin
 from argparse import ArgumentParser
 
 from datetime import timedelta
@@ -342,6 +343,8 @@ class Command(EnricherBaseCommand):
             url_str = (result.get(field) or '').strip()
             if not url_str:
                 continue
+            if not url_str.startswith(('http://', 'https://')):
+                url_str = urljoin(current.system_url.url, url_str)
             try:
                 norm = normalize_url(url_str)
                 existing = CitationUrl.objects.filter(url=norm).first()

--- a/dbdb/core/management/commands/enrich_system.py
+++ b/dbdb/core/management/commands/enrich_system.py
@@ -34,7 +34,7 @@ from dbdb.core.models import (
     System, SystemFeature, SystemVersion, AttributeOption,
 )
 from dbdb.core.utils.citations import crawl_citation_url, normalize_url, process_citation_url
-from dbdb.core.utils.enrichment import BaseEnricher, SYSTEM_ENRICHMENT_TOOL, build_url_extraction_tool
+from dbdb.core.utils.enrichment import BaseEnricher, build_system_enrichment_tool, build_url_extraction_tool
 from dbdb.core.utils.repositories import GitHubCollector
 from dbdb.core.utils.versions import clone_system_version, finalize_new_version
 
@@ -480,7 +480,8 @@ class Command(EnricherBaseCommand):
             LOG.debug(prompt)
             # sys.exit(1)
             try:
-                enrichment = enricher.call_llm(prompt, SYSTEM_ENRICHMENT_TOOL, model_override, dry_run=dry_run)
+                tool = build_system_enrichment_tool(missing_fields, missing_features, attributes)
+                enrichment = enricher.call_llm(prompt, tool, model_override, dry_run=dry_run)
             except Exception as e:
                 raise CommandError(f"LLM call failed: {e}")
         else:
@@ -490,18 +491,21 @@ class Command(EnricherBaseCommand):
                 prompt = enricher.build_system_prompt(system=system, current_version=current, fields=missing_fields,
                                                       features=[], attributes=attributes, crawled_pages=crawled_pages)
                 try:
-                    enrichment = enricher.call_llm(prompt, SYSTEM_ENRICHMENT_TOOL, model_override, dry_run=dry_run)
+                    tool = build_system_enrichment_tool(missing_fields, [], attributes)
+                    enrichment = enricher.call_llm(prompt, tool, model_override, dry_run=dry_run)
                 except Exception as e:
                     raise CommandError(f"LLM call failed: {e}")
 
-            enrichment.setdefault('features', {})
             enrichment.setdefault('citations', [])
             for feature in missing_features:
                 self.stdout.write(f"  Calling LLM for feature: {feature.label}")
                 prompt = enricher.build_feature_prompt(system, feature, crawled_pages)
                 try:
-                    result = enricher.call_llm(prompt, SYSTEM_ENRICHMENT_TOOL, model_override, dry_run=dry_run)
-                    enrichment['features'].update(result.get('features', {}))
+                    feature_tool = build_system_enrichment_tool([], [feature], [])
+                    result = enricher.call_llm(prompt, feature_tool, model_override, dry_run=dry_run)
+                    key = f"feature_{feature.get_sanitized_label()}"
+                    if key in result:
+                        enrichment[key] = result[key]
                     enrichment['citations'].extend(result.get('citations', []))
                 except Exception as e:
                     LOG.warning(f"LLM call failed for feature {feature.slug}: {e}")
@@ -634,25 +638,22 @@ class Command(EnricherBaseCommand):
                         self.stdout.write(f"  cite  {field}: {norm_url}")
 
             # Create SystemFeature rows for suggested features
-            feat_suggestions = enrichment.get('features', {})
-            if not isinstance(feat_suggestions, dict):
-                LOG.warning(f"LLM returned non-dict for 'features': {type(feat_suggestions).__name__} — skipping")
-                feat_suggestions = {}
-            features_by_slug = {f.slug: f for f in features}
-            for feat_slug, option_slugs in feat_suggestions.items():
-                feature = features_by_slug.get(feat_slug)
-                if feature is None:
-                    LOG.warning(f"Unknown feature keyword from LLM: {feat_slug}")
+            features_filled = []
+            for feature in missing_features:
+                key = f"feature_{feature.get_sanitized_label()}"
+                option_slugs = enrichment.get(key, [])
+                if isinstance(option_slugs, str):
+                    option_slugs = [option_slugs]
+                if not option_slugs:
                     continue
                 opts = list(
                     FeatureOption.objects.filter(
                         feature=feature,
-                        slug__in=option_slugs,
+                        slug__in=[s.lower() for s in option_slugs],
                     )
                 )
                 if not opts:
-                    self.stdout.write(f"  feat  {feat_slug}: no matching options for slugs {option_slugs}")
-                    LOG.warning(f"No matching options for feature {feat_slug}: {option_slugs}")
+                    LOG.warning(f"No matching options for feature {feature.slug}: {option_slugs}")
                     continue
                 sf, _ = SystemFeature.objects.get_or_create(
                     version=new_sv,
@@ -661,6 +662,7 @@ class Command(EnricherBaseCommand):
                 )
                 sf.options.set(opts)
                 self.stdout.write(f"  feat  {feature.label}: {', '.join(o.value for o in opts)}")
+                features_filled.append(feature.slug)
 
         verb = "Updated" if existing_pending else "Created"
         self.stdout.write(self.style.SUCCESS(
@@ -672,8 +674,8 @@ class Command(EnricherBaseCommand):
         ]
         if fields_filled:
             self.stdout.write(f"Fields filled: {', '.join(fields_filled)}")
-        if feat_suggestions:
-            self.stdout.write(f"Features set: {', '.join(feat_suggestions.keys())}")
+        if features_filled:
+            self.stdout.write(f"Features set: {', '.join(features_filled)}")
         from django.contrib.sites.models import Site
         domain = Site.objects.get_current().domain
         self.stdout.write(f"Review and approve: http://{domain}{new_sv.get_diff_url()}")

--- a/dbdb/core/management/commands/enrich_system.py
+++ b/dbdb/core/management/commands/enrich_system.py
@@ -214,13 +214,21 @@ class Command(EnricherBaseCommand):
                 time.sleep(sleep_secs)
             did_work = False
             try:
+                system.refresh_from_db()
+                try:
+                    current = SystemVersion.objects.prefetch_related(
+                        'project_types', 'licenses', 'oses', 'written_in',
+                        'features', 'features__options',
+                    ).get(system=system, is_current=True)
+                except SystemVersion.DoesNotExist:
+                    raise CommandError(f"No current SystemVersion for '{system.slug}'")
                 if add_tag:
-                    did_work = self._add_tag_one(system, tag_option, options)
+                    did_work = self._add_tag_one(system, current, tag_option, options)
                 else:
                     if do_enrich:
-                        did_work |= self._enrich_one(system, options)
+                        did_work |= self._enrich_one(system, current, options)
                     if do_extract_urls:
-                        did_work |= self._extract_urls_one(system, options)
+                        did_work |= self._extract_urls_one(system, current, options)
                 processed += 1
             except Exception as e:
                 did_work = True  # work was started before the failure
@@ -229,14 +237,8 @@ class Command(EnricherBaseCommand):
                 self.stderr.write(self.style.ERROR(f"Error enriching '{system.slug}': {e}"))
             prev_did_work = did_work
 
-    def _add_tag_one(self, system: System, tag_option: AttributeOption, options: dict) -> bool:
-        system.refresh_from_db()
+    def _add_tag_one(self, system: System, current: SystemVersion, tag_option: AttributeOption, options: dict) -> bool:
         dry_run: bool = options['dry_run']
-
-        try:
-            current = SystemVersion.objects.get(system=system, is_current=True)
-        except SystemVersion.DoesNotExist:
-            raise CommandError(f"No current SystemVersion for '{system.slug}'")
 
         if current.tags.filter(pk=tag_option.pk).exists():
             self.stdout.write(f"  '{system.name}' already has tag '{tag_option.name}', skipping")
@@ -263,14 +265,8 @@ class Command(EnricherBaseCommand):
         ))
         return True
 
-    def _extract_urls_one(self, system: System, options: dict, *, enricher=None) -> bool:
-        system.refresh_from_db()
+    def _extract_urls_one(self, system: System, current: SystemVersion, options: dict, *, enricher=None) -> bool:
         dry_run: bool = options['dry_run']
-
-        try:
-            current = SystemVersion.objects.get(system=system, is_current=True)
-        except SystemVersion.DoesNotExist:
-            raise CommandError(f"No current SystemVersion for '{system.slug}'")
 
         if current.system_url_id is None:
             LOG.info("Skipping '%s': no system_url to crawl", system.slug)
@@ -407,9 +403,7 @@ class Command(EnricherBaseCommand):
         ))
         return True
 
-    def _enrich_one(self, system: System, options: dict) -> bool:
-        system.refresh_from_db()
-
+    def _enrich_one(self, system: System, current: SystemVersion, options: dict) -> bool:
         dry_run: bool = options['dry_run']
         model_override: str | None = options['model']
         per_feature: bool = options['per_feature']
@@ -417,15 +411,6 @@ class Command(EnricherBaseCommand):
             [f.strip() for f in options['fields'].split(',')]
             if options['fields'] else None
         )
-
-        # --- 1. Load current version ---
-        try:
-            current = SystemVersion.objects.prefetch_related(
-                'project_types', 'licenses', 'oses', 'written_in',
-                'features', 'features__options',
-            ).get(system=system, is_current=True)
-        except SystemVersion.DoesNotExist:
-            raise CommandError(f"No current SystemVersion for '{system.slug}'")
 
         self.stdout.write(f"System: {system.name} (current ver #{current.ver})")
         enricher = BaseEnricher.create(options['enricher'])

--- a/dbdb/core/management/commands/enrich_system.py
+++ b/dbdb/core/management/commands/enrich_system.py
@@ -378,18 +378,27 @@ class Command(EnricherBaseCommand):
             self.stdout.write(f"  '{system.name}': nothing extracted from homepage")
             return True
 
+        extracted_fields = list(new_urls.keys())
+        if new_twitter_handle is not None:
+            extracted_fields.append('twitter_handle')
+        new_comment = f"URL extraction by enrich_system: {', '.join(extracted_fields)}"
+
         bot_user = User.objects.get(username=settings.DBDB_BOT_ACCOUNT)
         with transaction.atomic():
             pending = system.pending_version()
             if pending:
                 new_sv = pending
                 self.stdout.write(f"  Reusing existing pending SystemVersion #{new_sv.ver}")
+                if new_sv.comment:
+                    new_sv.comment = f"{new_sv.comment}\n{new_comment}"
+                else:
+                    new_sv.comment = new_comment
             else:
                 new_sv = clone_system_version(
                     current,
                     approved=False,
                     creator=bot_user,
-                    comment='Auto URL extraction by enrich_system command',
+                    comment=new_comment,
                 )
             for field, citation in new_urls.items():
                 setattr(new_sv, field, citation)
@@ -537,22 +546,20 @@ class Command(EnricherBaseCommand):
 
         with transaction.atomic():
             last_model = enricher.get_last_model()
-            enrichment_comment = f"Auto-enriched by enrich_system command (model: {last_model})"
             existing_pending = system.pending_version()
             if existing_pending:
                 new_sv = existing_pending
-                new_sv.comment = enrichment_comment
                 self.stdout.write(f"Reusing existing pending SystemVersion #{new_sv.ver}")
             else:
                 new_sv = clone_system_version(
                     current,
                     approved=False,
                     creator=bot_user,
-                    comment=enrichment_comment,
+                    comment=f"Auto-enriched by enrich_system (model: {last_model})",
                 )
 
             # Apply simple text / int fields
-            dirty = False
+            changed_fields: list[str] = []
             for field in SIMPLE_TEXT_FIELDS:
                 if field in missing_fields:
                     val = enrichment.get(field, '')
@@ -560,7 +567,7 @@ class Command(EnricherBaseCommand):
                         if field == 'twitter_handle' and field[0] != '@':
                             val = f"@{val}"
                         setattr(new_sv, field, val)
-                        dirty = True
+                        changed_fields.append(field)
 
             for field in INT_FIELDS:
                 if field in missing_fields:
@@ -568,7 +575,7 @@ class Command(EnricherBaseCommand):
                     if val:
                         try:
                             setattr(new_sv, field, int(val))
-                            dirty = True
+                            changed_fields.append(field)
                         except (TypeError, ValueError):
                             LOG.warning(f"  {field}: LLM returned non-integer {val!r}, skipping")
 
@@ -587,7 +594,7 @@ class Command(EnricherBaseCommand):
                             LOG.warning(f"  {field}: existing citation {url_str!r} has status {CitationUrl.Status(existing.status).name}, skipping")
                         else:
                             setattr(new_sv, field, existing)
-                            dirty = True
+                            changed_fields.append(field)
                         continue
                     # New URL: create, validate, keep only if reachable
                     citation = CitationUrl.objects.create(url=norm, status=CitationUrl.Status.UNKNOWN)
@@ -595,19 +602,16 @@ class Command(EnricherBaseCommand):
                     if info is None:
                         # Merged into an existing CitationUrl
                         setattr(new_sv, field, citation)
-                        dirty = True
+                        changed_fields.append(field)
                     elif info['status'] == CitationUrl.Status.VALID:
                         citation.save()
                         setattr(new_sv, field, citation)
-                        dirty = True
+                        changed_fields.append(field)
                     else:
                         LOG.warning(f"  {field}: {url_str!r} is unreachable (status={citation.get_status_display()}), skipping")
                         citation.delete()
                 except Exception as e:
                     LOG.warning(f"  {field}: could not validate {url_str!r}: {e}")
-
-            if dirty:
-                new_sv.save()
 
             # Apply M2M attribute fields
             for field, attr_slug in M2M_ATTR_SLUGS.items():
@@ -626,6 +630,7 @@ class Command(EnricherBaseCommand):
                 if opts:
                     getattr(new_sv, field).add(*opts)
                     self.stdout.write(f"  attr  {field}: {', '.join(o.name for o in opts)}")
+                    changed_fields.append(field)
                 else:
                     self.stdout.write(f"  attr  {field}: no matching options for slugs {slugs}")
 
@@ -663,6 +668,17 @@ class Command(EnricherBaseCommand):
                 sf.options.set(opts)
                 self.stdout.write(f"  feat  {feature.label}: {', '.join(o.value for o in opts)}")
                 features_filled.append(feature.slug)
+
+            # Update comment with the list of changed fields, appending to any existing text
+            all_changed = changed_fields + [f"feature:{s}" for s in features_filled]
+            new_comment = f"Auto-enriched by enrich_system (model: {last_model})"
+            if all_changed:
+                new_comment += f": {', '.join(all_changed)}"
+            if existing_pending and new_sv.comment:
+                new_sv.comment = f"{new_sv.comment}\n{new_comment}"
+            else:
+                new_sv.comment = new_comment
+            new_sv.save()
 
         verb = "Updated" if existing_pending else "Created"
         self.stdout.write(self.style.SUCCESS(

--- a/dbdb/core/management/commands/enrich_system.py
+++ b/dbdb/core/management/commands/enrich_system.py
@@ -276,7 +276,7 @@ class Command(EnricherBaseCommand):
             return False
 
         if current.system_url.status in (CitationUrl.Status.DEAD, CitationUrl.Status.SPAM):
-            LOG.info("Skipping '%s': system_url status is %s", system.slug, current.system_url.status.name)
+            LOG.info("Skipping '%s': system_url status is %s", system.slug, CitationUrl.Status(current.system_url.status).name)
             return False
 
         # Determine which URL fields are missing on the current version.
@@ -335,65 +335,47 @@ class Command(EnricherBaseCommand):
             if all(result.get(k) for k in expected_keys):
                 break
 
-        new_docs_url = None
-        new_blog_url = None
+        # Resolve CitationUrl FK fields via a shared loop
+        url_fk_fields = [f for f in ('docs_url', 'blog_url') if f in missing]
+        new_urls: dict = {}
+        for field in url_fk_fields:
+            url_str = (result.get(field) or '').strip()
+            if not url_str:
+                continue
+            try:
+                norm = normalize_url(url_str)
+                existing = CitationUrl.objects.filter(url=norm).first()
+                if existing:
+                    if existing.status in (CitationUrl.Status.DEAD, CitationUrl.Status.SPAM):
+                        LOG.warning("%s: %r has status %s, skipping", field, url_str, CitationUrl.Status(existing.status).name)
+                    else:
+                        new_urls[field] = existing
+                else:
+                    citation = CitationUrl.objects.create(url=norm, status=CitationUrl.Status.UNKNOWN)
+                    citation, info = process_citation_url(citation, system=system, skip_spamcheck=options['skip_spamcheck'])
+                    if info is None or info['status'] == CitationUrl.Status.VALID:
+                        if info is not None:
+                            citation.save()
+                        new_urls[field] = citation
+                    else:
+                        LOG.warning("%s: %r is unreachable, skipping", field, url_str)
+                        citation.delete()
+            except Exception as e:
+                LOG.warning("%s: could not validate %r: %s", field, url_str, e)
+
+        # twitter_handle is a plain string field, not a CitationUrl FK
         new_twitter_handle = None
-
-        if 'docs_url' in missing:
-            url_str = (result.get('docs_url') or '').strip()
-            if url_str:
-                try:
-                    norm = normalize_url(url_str)
-                    existing = CitationUrl.objects.filter(url=norm).first()
-                    if existing:
-                        new_docs_url = existing
-                    else:
-                        citation = CitationUrl.objects.create(url=norm, status=CitationUrl.Status.UNKNOWN)
-                        citation, info = process_citation_url(citation, system=system, skip_spamcheck=options['skip_spamcheck'])
-                        if info is None or info['status'] == CitationUrl.Status.VALID:
-                            if info is not None:
-                                citation.save()
-                            new_docs_url = citation
-                        else:
-                            LOG.warning("docs_url: %r is unreachable, skipping", url_str)
-                            citation.delete()
-                except Exception as e:
-                    LOG.warning("docs_url: could not validate %r: %s", url_str, e)
-
-        if 'blog_url' in missing:
-            url_str = (result.get('blog_url') or '').strip()
-            if url_str:
-                try:
-                    norm = normalize_url(url_str)
-                    existing = CitationUrl.objects.filter(url=norm).first()
-                    if existing:
-                        new_blog_url = existing
-                    else:
-                        citation = CitationUrl.objects.create(url=norm, status=CitationUrl.Status.UNKNOWN)
-                        citation, info = process_citation_url(citation, system=system, skip_spamcheck=options['skip_spamcheck'])
-                        if info is None or info['status'] == CitationUrl.Status.VALID:
-                            if info is not None:
-                                citation.save()
-                            new_blog_url = citation
-                        else:
-                            LOG.warning("blog_url: %r is unreachable, skipping", url_str)
-                            citation.delete()
-                except Exception as e:
-                    LOG.warning("blog_url: could not validate %r: %s", url_str, e)
-
         if 'twitter_handle' in missing:
             raw_twitter = (result.get('twitter_url') or '').strip()
             if raw_twitter:
                 new_twitter_handle = _extract_twitter_handle(raw_twitter)
 
         if dry_run:
-            self.stdout.write(
-                f"  [DRY RUN] docs_url={new_docs_url!r}, blog_url={new_blog_url!r}, "
-                f"twitter_handle={new_twitter_handle!r}"
-            )
+            url_parts = [f"{f}={new_urls.get(f)!r}" for f in ('docs_url', 'blog_url')]
+            self.stdout.write(f"  [DRY RUN] {', '.join(url_parts)}, twitter_handle={new_twitter_handle!r}")
             return True
 
-        if new_docs_url is None and new_blog_url is None and new_twitter_handle is None:
+        if not new_urls and new_twitter_handle is None:
             self.stdout.write(f"  '{system.name}': nothing extracted from homepage")
             return True
 
@@ -410,17 +392,15 @@ class Command(EnricherBaseCommand):
                     creator=bot_user,
                     comment='Auto URL extraction by enrich_system command',
                 )
-            if new_docs_url is not None:
-                new_sv.docs_url = new_docs_url
-            if new_blog_url is not None:
-                new_sv.blog_url = new_blog_url
+            for field, citation in new_urls.items():
+                setattr(new_sv, field, citation)
             if new_twitter_handle is not None:
                 new_sv.twitter_handle = new_twitter_handle
             new_sv.save()
 
+        url_parts = [f"{f}={new_urls.get(f)}" for f in ('docs_url', 'blog_url')]
         self.stdout.write(self.style.SUCCESS(
-            f"  Extracted for '{system.name}': "
-            f"docs_url={new_docs_url}, blog_url={new_blog_url}, twitter_handle={new_twitter_handle}"
+            f"  Extracted for '{system.name}': {', '.join(url_parts)}, twitter_handle={new_twitter_handle}"
         ))
         return True
 
@@ -611,8 +591,11 @@ class Command(EnricherBaseCommand):
                     norm = normalize_url(url_str)
                     existing = CitationUrl.objects.filter(url=norm).first()
                     if existing:
-                        setattr(new_sv, field, existing)
-                        dirty = True
+                        if existing.status in (CitationUrl.Status.DEAD, CitationUrl.Status.SPAM):
+                            LOG.warning(f"  {field}: existing citation {url_str!r} has status {CitationUrl.Status(existing.status).name}, skipping")
+                        else:
+                            setattr(new_sv, field, existing)
+                            dirty = True
                         continue
                     # New URL: create, validate, keep only if reachable
                     citation = CitationUrl.objects.create(url=norm, status=CitationUrl.Status.UNKNOWN)

--- a/dbdb/core/tests/test_enrichment.py
+++ b/dbdb/core/tests/test_enrichment.py
@@ -21,7 +21,7 @@ from dbdb.core.management.commands.enrich_organization import (
     _validate_crunchbase_url,
     _validate_linkedin_url,
 )
-from dbdb.core.models import Attribute, CitationUrl, CitationUrlContent, Organization, System, SystemVersion
+from dbdb.core.models import Attribute, AttributeOption, CitationUrl, CitationUrlContent, Organization, System, SystemVersion
 from dbdb.core.utils.enrichment.base import BaseEnricher
 from dbdb.core.utils.versions import clone_system_version
 
@@ -499,3 +499,70 @@ class HomepageUrlOrgExtractionTestCase(TestCase):
 
         self.org.refresh_from_db()
         self.assertIsNone(self.org.linkedin_url_id)
+
+
+# ---------------------------------------------------------------------------
+# clone_system_version M2M field copy
+# ---------------------------------------------------------------------------
+
+@override_settings(DBDB_BOT_ACCOUNT='admin')
+class CloneSystemVersionM2MTestCase(TestCase):
+    """
+    Regression: copy.copy() shares _prefetched_objects_cache with the source
+    object, so M2M fields that were prefetch_related before cloning end up
+    empty on the new SystemVersion (the stale cache makes Django believe the
+    through-table rows already exist).  tags is unaffected because
+    enrich_system.py does not prefetch it.
+    """
+
+    fixtures = _FIXTURES
+
+    def setUp(self):
+        self.system = System.objects.get(slug='sqlite')
+        self.version = SystemVersion.objects.get(system=self.system, is_current=True)
+        self.admin_user = User.objects.get(username='admin')
+
+        def _opt(attr_slug, slug, name):
+            attr = Attribute.objects.get(slug=attr_slug)
+            opt, _ = AttributeOption.objects.get_or_create(
+                attribute=attr, slug=slug, defaults={'name': name}
+            )
+            return opt
+
+        self.opt_project_type = _opt('project-type', 'commercial', 'Commercial')
+        self.opt_license      = _opt('license', 'apache-2', 'Apache 2')
+        self.opt_os           = _opt('os', 'linux', 'Linux')
+        self.opt_written_in   = _opt('programming-language', 'c', 'C')
+        self.opt_tag          = _opt('tag', 'relational', 'Relational')
+
+        self.version.project_types.add(self.opt_project_type)
+        self.version.licenses.add(self.opt_license)
+        self.version.oses.add(self.opt_os)
+        self.version.written_in.add(self.opt_written_in)
+        self.version.tags.add(self.opt_tag)
+
+    def _assert_m2m(self, clone):
+        """Assert that all options added in setUp are present on the clone."""
+        self.assertIn(self.opt_project_type, list(clone.project_types.all()))
+        self.assertIn(self.opt_license,      list(clone.licenses.all()))
+        self.assertIn(self.opt_os,           list(clone.oses.all()))
+        self.assertIn(self.opt_written_in,   list(clone.written_in.all()))
+        self.assertIn(self.opt_tag,          list(clone.tags.all()))
+
+    def test_m2m_fields_copied_when_source_is_prefetched(self):
+        """All M2M fields survive cloning even when the source was loaded with
+        prefetch_related, which is how enrich_system.py always loads versions."""
+        prefetched = SystemVersion.objects.prefetch_related(
+            'project_types', 'licenses', 'oses', 'written_in',
+            'features', 'features__options',
+        ).get(pk=self.version.pk)
+
+        clone = clone_system_version(prefetched, creator=self.admin_user, comment='test')
+
+        self._assert_m2m(clone)
+
+    def test_m2m_fields_copied_without_prefetch(self):
+        """Baseline: M2M fields are copied correctly when source is not prefetched."""
+        clone = clone_system_version(self.version, creator=self.admin_user, comment='test')
+
+        self._assert_m2m(clone)

--- a/dbdb/core/tests/test_enrichment.py
+++ b/dbdb/core/tests/test_enrichment.py
@@ -233,7 +233,7 @@ class HomepageUrlSystemExtractionTestCase(TestCase):
     def _call(self, enricher, **opt_overrides):
         opts = _options(**opt_overrides)
         with _NO_OP_CRAWL:
-            self.cmd._extract_urls_one(self.system, opts, enricher=enricher)
+            self.cmd._extract_urls_one(self.system, self.current, opts, enricher=enricher)
 
     def test_extracts_docs_url_creates_pending_version(self):
         # Pre-create the docs CitationUrl so the code reuses it (bypasses HTTP)

--- a/dbdb/core/tests/test_enrichment.py
+++ b/dbdb/core/tests/test_enrichment.py
@@ -352,6 +352,18 @@ class HomepageUrlSystemExtractionTestCase(TestCase):
 
         self.assertIsNone(self.system.pending_version())
 
+    def test_relative_docs_url_resolved_against_homepage(self):
+        docs_citation = CitationUrl.objects.create(
+            url='https://sqlite.org/docs',
+            status=CitationUrl.Status.VALID,
+        )
+        enricher = MockEnricher({'docs_url': '/docs'})
+        self._call(enricher)
+
+        pending = self.system.pending_version()
+        self.assertIsNotNone(pending)
+        self.assertEqual(pending.docs_url_id, docs_citation.pk)
+
 
 # ---------------------------------------------------------------------------
 # HomepageUrlOrgExtractionTestCase
@@ -475,6 +487,15 @@ class HomepageUrlOrgExtractionTestCase(TestCase):
     def test_dry_run_does_not_save(self):
         enricher = MockEnricher({'linkedin_url': 'https://www.linkedin.com/company/wu-tang-financial'})
         self._call(enricher, dry_run=True)
+
+        self.org.refresh_from_db()
+        self.assertIsNone(self.org.linkedin_url_id)
+
+    def test_relative_url_rejected_by_validator(self):
+        # Relative paths can't resolve to a valid linkedin/crunchbase URL, so
+        # they are logged as invalid and the field is left unset.
+        enricher = MockEnricher({'linkedin_url': '/company/wu-tang-financial'})
+        self._call(enricher)
 
         self.org.refresh_from_db()
         self.assertIsNone(self.org.linkedin_url_id)

--- a/dbdb/core/tests/test_enrichment.py
+++ b/dbdb/core/tests/test_enrichment.py
@@ -332,6 +332,26 @@ class HomepageUrlSystemExtractionTestCase(TestCase):
 
         self.assertIsNone(self.system.pending_version())
 
+    def test_dead_existing_docs_url_not_assigned(self):
+        CitationUrl.objects.create(
+            url='https://sqlite.org/docs',
+            status=CitationUrl.Status.DEAD,
+        )
+        enricher = MockEnricher({'docs_url': 'https://sqlite.org/docs'})
+        self._call(enricher)
+
+        self.assertIsNone(self.system.pending_version())
+
+    def test_dead_existing_blog_url_not_assigned(self):
+        CitationUrl.objects.create(
+            url='https://sqlite.org/blog',
+            status=CitationUrl.Status.DEAD,
+        )
+        enricher = MockEnricher({'blog_url': 'https://sqlite.org/blog'})
+        self._call(enricher)
+
+        self.assertIsNone(self.system.pending_version())
+
 
 # ---------------------------------------------------------------------------
 # HomepageUrlOrgExtractionTestCase

--- a/dbdb/core/utils/enrichment/__init__.py
+++ b/dbdb/core/utils/enrichment/__init__.py
@@ -11,7 +11,7 @@ from .chatgpt import ChatGPTEnricher
 from .perplexity import PerplexityEnricher
 from .schema import (
     get_system_prompt,
-    SYSTEM_ENRICHMENT_TOOL,
+    build_system_enrichment_tool,
     build_org_enrichment_tool,
     build_url_extraction_tool,
     DOC_ENRICHMENT_TOOL,
@@ -24,11 +24,10 @@ __all__ = [
     "ChatGPTEnricher",
     "PerplexityEnricher",
     "get_system_prompt",
-    "SYSTEM_ENRICHMENT_TOOL",
+    "build_system_enrichment_tool",
     "build_org_enrichment_tool",
     "build_url_extraction_tool",
     "DOC_ENRICHMENT_TOOL",
-    "call_llm",
     "validate_citations",
     "build_full_prompt",
     "build_feature_prompt",
@@ -38,12 +37,6 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Backward-compat module-level wrappers
 # ---------------------------------------------------------------------------
-
-def call_llm(enricher_type: str, user_prompt: str, model_override: str | None = None) -> dict:
-    return BaseEnricher.create(enricher_type, model_override).call_llm(
-        user_prompt, SYSTEM_ENRICHMENT_TOOL, model_override
-    )
-
 
 def validate_citations(enricher_type: str, raw_citations: list, system) -> dict:
     return BaseEnricher.create(enricher_type).validate_citations(raw_citations, system)

--- a/dbdb/core/utils/enrichment/schema.py
+++ b/dbdb/core/utils/enrichment/schema.py
@@ -49,104 +49,125 @@ def get_system_prompt(tool_name: str, name: str = '', organization: str = '') ->
 # System enrichment schema
 # ---------------------------------------------------------------------------
 
-SYSTEM_ENRICHMENT_TOOL = {
-    "name": "save_enrichment",
-    "description": (
-        "Save extracted information about a database system. "
-        "Only include fields you are confident about. "
-        "All option slugs must match exactly the provided taxonomy."
-    ),
-    "input_schema": {
+_SYSTEM_FIELD_SCHEMAS: dict[str, dict] = {
+    "description": {
+        "type": "string",
+        "description": "Prose summary of what the system is and the workloads it targets.",
+    },
+    "history": {
+        "type": "string",
+        "description": "Narrative of the system's origins, milestones, and lineage.",
+    },
+    "start_year": {
+        "type": "integer",
+        "description": "Year the project was first released or publicly announced.",
+    },
+    "end_year": {
+        "type": ["integer", "null"],
+        "description": "Year active development ceased, or null if still active.",
+    },
+    "system_url": {
+        "type": "string",
+        "description": "Official homepage URL.",
+    },
+    "docs_url": {
+        "type": "string",
+        "description": "Official technical documentation URL.",
+    },
+    "blog_url": {
+        "type": "string",
+        "description": "Engineering blog URL for the database system.",
+    },
+    "sourcerepo_url": {
+        "type": "string",
+        "description": "Source code repository URL (e.g. GitHub).",
+    },
+    "wikipedia_url": {
+        "type": "string",
+        "description": "Wikipedia article URL.",
+    },
+    "twitter_handle": {
+        "type": "string",
+        "description": "Twitter/X handle (without @).",
+    },
+}
+
+_SYSTEM_CITATIONS_SCHEMA = {
+    "type": "array",
+    "description": "URLs that support the provided information.",
+    "items": {
         "type": "object",
+        "required": ["url", "fields"],
         "properties": {
-            "description": {
-                "type": "string",
-                "description": "Prose summary of what the system is and the workloads it targets.",
-            },
-            "history": {
-                "type": "string",
-                "description": "Narrative of the system's origins, milestones, and lineage.",
-            },
-            "start_year": {
-                "type": "integer",
-                "description": "Year the project was first released or publicly announced.",
-            },
-            "end_year": {
-                "type": ["integer", "null"],
-                "description": "Year active development ceased, or null if still active.",
-            },
-            "system_url": {
-                "type": "string",
-                "description": "Official homepage URL.",
-            },
-            "docs_url": {
-                "type": "string",
-                "description": "Official technical documentation URL.",
-            },
-            "blog_url": {
-                "type": "string",
-                "description": "Engineering blog URL for the database system.",
-            },
-            "wikipedia_url": {
-                "type": "string",
-                "description": "Wikipedia article URL.",
-            },
-            "twitter_handle": {
-                "type": "string",
-                "description": "Twitter/X handle (without @).",
-            },
-            "project_types": {
+            "url": {"type": "string"},
+            "fields": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "List of project-type AttributeOption slugs.",
-            },
-            "licenses": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "List of license AttributeOption slugs.",
-            },
-            "oses": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "List of OS AttributeOption slugs.",
-            },
-            "written_in": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "List of programming-language AttributeOption slugs.",
-            },
-            "tags": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "List of tag AttributeOption slugs that categorise the system.",
-            },
-            "features": {
-                "type": "object",
-                "description": "Map of feature_slug → [option_slug, …]. Only include features you are confident about.",
-                "additionalProperties": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                },
-            },
-            "citations": {
-                "type": "array",
-                "description": "URLs that support the provided information.",
-                "items": {
-                    "type": "object",
-                    "required": ["url", "fields"],
-                    "properties": {
-                        "url": {"type": "string"},
-                        "fields": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Field names this URL supports (e.g. ['description', 'start_year']).",
-                        },
-                    },
-                },
+                "description": "Field names this URL supports (e.g. ['description', 'start_year']).",
             },
         },
     },
 }
+
+
+def build_system_enrichment_tool(
+    missing_fields: list[str],
+    missing_features: list,
+    attributes: list,
+) -> dict:
+    """Return a save_enrichment tool schema scoped to missing fields and features.
+
+    missing_features: list[Feature] with options prefetched
+    attributes:       list[Attribute] with options prefetched
+    """
+    properties: dict = {}
+
+    # Static scalar / URL fields
+    for field in missing_fields:
+        if field in _SYSTEM_FIELD_SCHEMAS:
+            properties[field] = _SYSTEM_FIELD_SCHEMAS[field]
+
+    # M2M attribute fields — descriptions and option enums from the DB
+    attr_by_sv_field = {attr.sv_field: attr for attr in attributes}
+    for field in missing_fields:
+        attr = attr_by_sv_field.get(field)
+        if attr is None:
+            continue
+        slugs = [opt.slug for opt in attr.options.all()]
+        properties[field] = {
+            "type": "array",
+            "items": {"type": "string", "enum": slugs},
+            "description": attr.description or f"Select {attr.name} options.",
+        }
+
+    # Individual feature properties — flat keys, descriptions and option enums from the DB
+    for feature in missing_features:
+        key = f"feature_{feature.get_sanitized_label()}"
+        slugs = [opt.slug for opt in feature.options.all()]
+        if feature.multivalued:
+            properties[key] = {
+                "type": "array",
+                "items": {"type": "string", "enum": slugs},
+                "description": feature.description or feature.label,
+            }
+        else:
+            properties[key] = {
+                "type": "string",
+                "enum": slugs,
+                "description": feature.description or feature.label,
+            }
+
+    properties["citations"] = _SYSTEM_CITATIONS_SCHEMA
+
+    return {
+        "name": "save_enrichment",
+        "description": (
+            "Save extracted information about a database system. "
+            "Only include fields you are confident about. "
+            "All option slugs must match exactly the provided taxonomy."
+        ),
+        "input_schema": {"type": "object", "properties": properties},
+    }
 
 # ---------------------------------------------------------------------------
 # Organization enrichment schema

--- a/dbdb/core/utils/versions.py
+++ b/dbdb/core/utils/versions.py
@@ -395,6 +395,12 @@ def clone_system_version(
 
     new_version.save()
 
+    # Clear stale prefetch cache: copy.copy() shares it with the source, so
+    # after save() assigns a new pk the cached M2M querysets are bound to the
+    # wrong object and .set() silently inserts nothing.  Same fix is applied
+    # below for SystemFeature cloning.
+    new_version._prefetched_objects_cache = {}
+
     # Copy all M2M relationships from the previous version
     for field_name in _VERSION_M2M:
         getattr(new_version, field_name).set(


### PR DESCRIPTION
… URL loop

- Skip existing CitationUrl objects with DEAD/SPAM status when assigning
  to FK fields (docs_url, blog_url, etc.) in both enrich_system and
  enrich_organization — previously these were assigned without a status check
- Fix 'int' object has no attribute 'name' for system_url status log message
- Collapse the per-field docs_url/blog_url blocks in _extract_urls_one into
  a single loop using setattr(), matching the pattern in enrich_organization
- Add regression tests for dead-URL skip behavior

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012vVqiaUFuhzDDuTcPMKYEk