### PR TITLE
Add flock-based single-instance locking to cron scripts

### DIFF
--- a/scripts/collect_repos.sh
+++ b/scripts/collect_repos.sh
@@ -1,7 +1,11 @@
-#/bin/sh
+#!/bin/sh
 # Generate a new snapshot about each repository that is still active once a week.
 # Or check whether they have been abandoned.
 # This has to run on a machine that has storage space for all the collected repos.
+
+LOCKFILE="/run/lock/collect_repos.lock"
+exec 9>"$LOCKFILE"
+flock --nonblock 9 || { echo "collect_repos.sh: already running, exiting." >&2; exit 1; }
 
 uv run ./manage.py collect_repo_info --debug \
   --check-abandoned \

--- a/scripts/process_citations.sh
+++ b/scripts/process_citations.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+LOCKFILE="/run/lock/process_citations.lock"
+exec 9>"$LOCKFILE"
+flock --nonblock 9 || { echo "process_citations.sh: already running, exiting." >&2; exit 1; }
+
 COMMON_ARGS="--debug --normalize --skip-errors --sleep=30"
 
 # First process Github repos without spam checks

--- a/scripts/process_visits.sh
+++ b/scripts/process_visits.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # This should be run weekly to recompute the "People Who Viewed..."
 
+LOCKFILE="/run/lock/process_visits.lock"
+exec 9>"$LOCKFILE"
+flock --nonblock 9 || { echo "process_visits.sh: already running, exiting." >&2; exit 1; }
+
 uv run ./manage.py  process_visits --debug --clear --store \
   --min-visit=75 \
   --max-threshold=45 \

--- a/scripts/rotate_spotlight.sh
+++ b/scripts/rotate_spotlight.sh
@@ -3,4 +3,8 @@
 # Suggested cron entry (Monday midnight):
 #   0 0 * * 1  cd /path/to/web && ./scripts/rotate_spotlight.sh >> /var/log/dbdb/rotate_spotlight.log 2>&1
 
+LOCKFILE="/run/lock/rotate_spotlight.lock"
+exec 9>"$LOCKFILE"
+flock --nonblock 9 || { echo "rotate_spotlight.sh: already running, exiting." >&2; exit 1; }
+
 uv run ./manage.py rotate_spotlight


### PR DESCRIPTION
Each script now acquires an exclusive non-blocking lock on a file in /run/lock/ before doing any work. A second invocation while the first is still running exits immediately with a message to stderr (visible in cron mail). The lock is released automatically when the process exits. Also fixes the missing '!' in collect_repos.sh's shebang.


Claude-Session: https://claude.ai/code/session_012vVqiaUFuhzDDuTcPMKYEk