### PR TITLE
Fix TemplateSyntaxError in setup_user.html

### DIFF
--- a/templates/registration/setup_user.html
+++ b/templates/registration/setup_user.html
@@ -39,11 +39,9 @@
                             </span>
                         </div>
                     </div>
-                    {% buttons %}
-                        <button class="btn btn-primary" type="submit">
-                            Generate URL
-                        </button>
-                    {% endbuttons %}
+                    <button class="btn btn-primary" type="submit">
+                        Generate URL
+                    </button>
 
                     <samp id="url" class="d-none"></samp>
                 </form>


### PR DESCRIPTION
Remove crispy-forms {% buttons %} tag that was never loaded in this template, replacing it with a plain Bootstrap button element.


Claude-Session: https://claude.ai/code/session_01RsQ3awvsgsWYFCFsnY3j4w