### PR TITLE
Add --check-resurrection flag to collect_repo_info

### DIFF
--- a/dbdb/core/management/commands/collect_repo_info.py
+++ b/dbdb/core/management/commands/collect_repo_info.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from django.contrib.auth import get_user_model
 
 from dbdb.core.models import AttributeOption, RepositoryInfo, RepositorySnapshot, SystemVersion, SystemVersionCodingAgent
-from dbdb.core.utils.repository import check_abandoned, fetch_snapshot_data, scan_coding_agents
+from dbdb.core.utils.repository import check_abandoned, check_resurrection, fetch_snapshot_data, scan_coding_agents
 from dbdb.core.utils.versions import clone_system_version, finalize_new_version
 
 _FAILED_DISABLE_THRESHOLD = 3
@@ -50,6 +50,10 @@ class Command(DbdbBaseCommand):
         parser.add_argument(
             '--no-agents', action='store_true',
             help='Skip coding-agent co-authorship scan after each snapshot.')
+        parser.add_argument(
+            '--check-resurrection', action='store_true',
+            help='Scan systems tagged "Abandoned" for signs of recent activity and '
+                 'create a pending SystemVersion for admin review if any is found.')
         return
 
     def handle(self, *args, **options):
@@ -271,3 +275,34 @@ class Command(DbdbBaseCommand):
         self.stdout.write(
             self.style.SUCCESS(f"\nDone: {ok} updated, {skipped} skipped, {err} errors")
         )
+
+        if options['check_resurrection']:
+            abandoned_versions = (
+                SystemVersion.objects
+                .filter(is_current=True, sourcerepo_url__isnull=False, tags__slug='abandoned')
+                .select_related('sourcerepo_url', 'system')
+                .order_by('system__name')
+            )
+            res_ok = res_skipped = res_err = 0
+            for ver in abandoned_versions:
+                self.stdout.write(f"{ver.system.name}  {ver.sourcerepo_url.url}")
+                try:
+                    was_resurrected = check_resurrection(ver.system)
+                    if was_resurrected:
+                        self.stdout.write("  Flagged for resurrection — pending version created")
+                        res_ok += 1
+                    else:
+                        self.stdout.write("  No recent activity detected")
+                        res_skipped += 1
+                except ValueError as exc:
+                    LOG.debug("check_resurrection skipped for %s: %s", ver.system.slug, exc)
+                    res_skipped += 1
+                except Exception as exc:
+                    self.stderr.write(f"  ERROR — {exc}")
+                    LOG.exception("check_resurrection failed for %s", ver.system.slug)
+                    res_err += 1
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Resurrection check: {res_ok} flagged, {res_skipped} skipped, {res_err} errors"
+                )
+            )

--- a/dbdb/core/management/commands/collect_repo_info.py
+++ b/dbdb/core/management/commands/collect_repo_info.py
@@ -101,13 +101,18 @@ class Command(DbdbBaseCommand):
         sleep_secs = options['sleep']
         limit = options['limit']
         do_check_abandoned = options['check_abandoned']
+        do_resurrection = options['check_resurrection']
         no_collect = options['no_collect']
         no_agents = options['no_agents']
         inactivity_days = settings.REPOSITORY_INACTIVITY_DAYS
 
+        # When --check-resurrection is the only active flag, skip snapshot
+        # collection for enabled repos and focus solely on abandoned ones.
+        resurrection_only = do_resurrection and not do_check_abandoned
+
         ai_assisted_tag = None
         bot_user = None
-        if not no_agents:
+        if not no_agents and not resurrection_only:
             try:
                 ai_assisted_tag = AttributeOption.objects.get(
                     attribute__slug='tag', slug='ai-assisted'
@@ -121,10 +126,11 @@ class Command(DbdbBaseCommand):
 
         seen_citation_ids: set[int] = set()
         ok = err = skipped = 0
+        res_ok = res_err = res_skipped = 0
         first = True
 
-        if versions.count() == 0:
-            LOG.warning(f"No systems found!")
+        if not resurrection_only and versions.count() == 0:
+            LOG.warning("No systems found!")
 
         for ver in versions.order_by("system__name"):
             citation = ver.sourcerepo_url
@@ -134,9 +140,31 @@ class Command(DbdbBaseCommand):
             seen_citation_ids.add(citation.id)
 
             repo_info, _ = RepositoryInfo.objects.get_or_create(sourcerepo_url=citation)
+
             if not repo_info.enabled:
-                LOG.debug("Skipping disabled repo: %s", citation.url)
-                skipped += 1
+                if do_resurrection:
+                    self.stdout.write(f"{ver.system.name}  {citation.url}")
+                    try:
+                        was_resurrected = check_resurrection(ver.system)
+                        if was_resurrected:
+                            self.stdout.write("  Flagged for resurrection — pending version created")
+                            res_ok += 1
+                        else:
+                            self.stdout.write("  No recent activity detected")
+                            res_skipped += 1
+                    except ValueError as exc:
+                        LOG.debug("check_resurrection skipped for %s: %s", ver.system.slug, exc)
+                        res_skipped += 1
+                    except Exception as exc:
+                        self.stderr.write(f"  ERROR — {exc}")
+                        LOG.exception("check_resurrection failed for %s", ver.system.slug)
+                        res_err += 1
+                else:
+                    LOG.debug("Skipping disabled repo: %s", citation.url)
+                    skipped += 1
+                continue
+
+            if resurrection_only:
                 continue
 
             if ignore_days is not None and repo_info.last_snapshot is not None:
@@ -272,35 +300,11 @@ class Command(DbdbBaseCommand):
                 self.stdout.write(f"Limit of {limit} reached, stopping.")
                 break
 
-        self.stdout.write(
-            self.style.SUCCESS(f"\nDone: {ok} updated, {skipped} skipped, {err} errors")
-        )
-
-        if options['check_resurrection']:
-            abandoned_versions = (
-                SystemVersion.objects
-                .filter(is_current=True, sourcerepo_url__isnull=False, tags__slug='abandoned')
-                .select_related('sourcerepo_url', 'system')
-                .order_by('system__name')
+        if not resurrection_only:
+            self.stdout.write(
+                self.style.SUCCESS(f"\nDone: {ok} updated, {skipped} skipped, {err} errors")
             )
-            res_ok = res_skipped = res_err = 0
-            for ver in abandoned_versions:
-                self.stdout.write(f"{ver.system.name}  {ver.sourcerepo_url.url}")
-                try:
-                    was_resurrected = check_resurrection(ver.system)
-                    if was_resurrected:
-                        self.stdout.write("  Flagged for resurrection — pending version created")
-                        res_ok += 1
-                    else:
-                        self.stdout.write("  No recent activity detected")
-                        res_skipped += 1
-                except ValueError as exc:
-                    LOG.debug("check_resurrection skipped for %s: %s", ver.system.slug, exc)
-                    res_skipped += 1
-                except Exception as exc:
-                    self.stderr.write(f"  ERROR — {exc}")
-                    LOG.exception("check_resurrection failed for %s", ver.system.slug)
-                    res_err += 1
+        if do_resurrection:
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Resurrection check: {res_ok} flagged, {res_skipped} skipped, {res_err} errors"

--- a/dbdb/core/management/commands/enrich_organization.py
+++ b/dbdb/core/management/commands/enrich_organization.py
@@ -28,7 +28,7 @@ from django.utils.text import slugify
 from django_countries.fields import CountryField
 
 from dbdb.core.management.base import EnricherBaseCommand
-from dbdb.core.models import CitationUrl, Organization, OrgType, StockExchange, SystemVersion
+from dbdb.core.models import AttributeOption, CitationUrl, Organization, OrgType, SystemVersion
 from dbdb.core.utils.citations import crawl_citation_url, normalize_url, process_citation_url
 from dbdb.core.utils.enrichment import BaseEnricher, build_org_enrichment_tool, build_url_extraction_tool
 
@@ -44,8 +44,7 @@ ORG_ALL_FIELDS = (
 
 # Maps display label → integer value for IntegerChoices fields.
 _ORG_CHOICE_MAPS = {
-    'org_type':      {label: value for value, label in OrgType.choices},
-    'stock_exchange': {label: value for value, label in StockExchange.choices},
+    'org_type': {label: value for value, label in OrgType.choices},
 }
 
 
@@ -53,6 +52,9 @@ def _org_field_type(field_name: str) -> str:
     """Return the storage category of an Organization field via reflection."""
     field = Organization._meta.get_field(field_name)
     if isinstance(field, models.ForeignKey):
+        lc = field.remote_field.limit_choices_to or {}
+        if isinstance(lc, dict) and 'attribute__slug' in lc:
+            return 'attr_option'
         return 'url'
     if isinstance(field, models.IntegerField) and field.choices:
         return 'choice'
@@ -63,7 +65,7 @@ def _org_field_type(field_name: str) -> str:
 
 def _is_org_field_empty(org: Organization, field: str) -> bool:
     ft = _org_field_type(field)
-    if ft == 'url':
+    if ft in ('url', 'attr_option'):
         return getattr(org, f'{field}_id') is None
     if ft == 'choice':
         return getattr(org, field) is None
@@ -74,7 +76,7 @@ def _query_orgs_missing_field(field: str):
     """Return a queryset of Organizations that have *field* empty/null."""
     from django.db.models import Q
     ft = _org_field_type(field)
-    if ft == 'url':
+    if ft in ('url', 'attr_option'):
         return Organization.objects.filter(**{f'{field}_id__isnull': True})
     if ft == 'choice':
         return Organization.objects.filter(**{f'{field}__isnull': True})
@@ -339,6 +341,18 @@ class Command(EnricherBaseCommand):
                     dirty = True
                 elif label:
                     LOG.warning(f"  {field}: unrecognised value {label!r}, skipping")
+
+            elif ft == 'attr_option':
+                label = (val or '').strip()
+                if label:
+                    field_obj = Organization._meta.get_field(field)
+                    attr_slug = field_obj.remote_field.limit_choices_to.get('attribute__slug')
+                    opt = AttributeOption.objects.filter(attribute__slug=attr_slug, name=label).first()
+                    if opt is not None:
+                        setattr(org, field, opt)
+                        dirty = True
+                    else:
+                        LOG.warning(f"  {field}: unrecognised value {label!r}, skipping")
 
             elif ft == 'array':
                 if isinstance(val, list) and val:

--- a/dbdb/core/management/commands/enrich_system.py
+++ b/dbdb/core/management/commands/enrich_system.py
@@ -110,7 +110,12 @@ def _crawl_existing_urls(
 
 
 def _query_systems_missing_field(field: str):
-    """Return a queryset of Systems whose current version has *field* empty/null."""
+    """Return a queryset of Systems whose current version has *field* empty/null.
+
+    *field* may be a regular SystemVersion field name or a Feature slug, in
+    which case systems whose current version has no selected FeatureOption for
+    that Feature are returned.
+    """
     from django.db.models import Q
     sv_qs = SystemVersion.objects.filter(is_current=True)
     if field in URL_FK_FIELDS:
@@ -119,8 +124,17 @@ def _query_systems_missing_field(field: str):
         sv_qs = sv_qs.filter(**{f'{field}__isnull': True})
     elif field in SIMPLE_TEXT_FIELDS:
         sv_qs = sv_qs.filter(Q(**{f'{field}__isnull': True}) | Q(**{field: ''}))
-    else:  # INT_FIELDS
+    elif field in INT_FIELDS:
         sv_qs = sv_qs.filter(**{f'{field}__isnull': True})
+    else:
+        # Feature slug — exclude versions that already have options set for it
+        sv_with_feature = (
+            SystemFeature.objects
+            .filter(feature__slug=field)
+            .exclude(options=None)
+            .values_list('version_id', flat=True)
+        )
+        sv_qs = sv_qs.exclude(id__in=sv_with_feature)
     return System.objects.filter(versions__in=sv_qs).order_by('name')
 
 
@@ -143,11 +157,10 @@ class Command(EnricherBaseCommand):
         parser.add_argument('--per-feature', action='store_true',
                             help='One LLM call per missing Feature (slower, more targeted)')
         all_fields = list(SIMPLE_TEXT_FIELDS) + list(INT_FIELDS) + list(URL_FK_FIELDS) + list(M2M_ATTR_FIELDS)
-        parser.add_argument('--missing', metavar='FIELD', default=None,
-                            choices=all_fields,
-                            help=f'Process every system whose current version is missing FIELD '
-                                 f'(instead of providing KEYWORDs). '
-                                 f'Valid fields: {", ".join(all_fields)}')
+        parser.add_argument('--missing', metavar='FIELD_OR_FEATURE', default=None,
+                            help=f'Process every system whose current version is missing FIELD_OR_FEATURE. '
+                                 f'Pass a regular field name ({", ".join(all_fields)}) or a Feature slug '
+                                 f'(e.g. data-model) to target systems missing that feature.')
         parser.add_argument('--add-tag', metavar='TAG', default=None,
                             help='Create a new approved SystemVersion adding TAG to the target '
                                  'systems (matched by name or slug). Skips LLM enrichment.')
@@ -171,6 +184,13 @@ class Command(EnricherBaseCommand):
             self.stdout.write(f"Tag: {tag_option.name} (slug={tag_option.slug})")
 
         if missing_field:
+            all_fields = list(SIMPLE_TEXT_FIELDS) + list(INT_FIELDS) + list(URL_FK_FIELDS) + list(M2M_ATTR_FIELDS)
+            if missing_field not in all_fields:
+                if not Feature.objects.filter(slug=missing_field).exists():
+                    raise CommandError(
+                        f"'{missing_field}' is not a recognised field or Feature slug. "
+                        f"Valid fields: {', '.join(all_fields)}"
+                    )
             for system in _query_systems_missing_field(missing_field):
                 seen[system.pk] = system
         else:

--- a/dbdb/core/management/commands/import_systems.py
+++ b/dbdb/core/management/commands/import_systems.py
@@ -10,7 +10,7 @@ CSV format:
   - All other columns are matched by header name to SystemVersion fields:
 
     URL fields (creates/reuses a CitationUrl):
-      system_url, docs_url, sourcerepo_url, wikipedia_url
+      system_url, docs_url, sourcerepo_url, wikipedia_url, twitter_url
 
     Country field (2-char ISO code):
       countries
@@ -21,7 +21,7 @@ CSV format:
     Integer fields:
       start_year, end_year
 
-    Organization field (name; looked up or created):
+    Organization field (name or slug; looked up case-insensitively or created):
       developer_orgs
 
   Unknown header names are skipped with a warning.
@@ -55,7 +55,7 @@ LOG = logging.getLogger(__name__)
 User = get_user_model()
 
 _LOGO_EXTENSIONS   = ('svg', 'png', 'jpg', 'jpeg')
-_URL_FIELDS        = frozenset({'system_url', 'docs_url', 'sourcerepo_url', 'wikipedia_url'})
+_URL_FIELDS        = frozenset({'system_url', 'docs_url', 'sourcerepo_url', 'wikipedia_url', 'twitter_url'})
 _COUNTRY_FIELDS    = frozenset({'countries'})
 _TEXT_FIELDS       = frozenset({'description', 'history', 'twitter_handle'})
 _INT_FIELDS        = frozenset({'start_year', 'end_year'})
@@ -122,8 +122,11 @@ def _resolve_systems(raw: str) -> list:
 
 
 def _get_or_create_org(name: str, *, dry_run: bool) -> 'Organization | None':
-    """Look up an Organization by name (case-insensitive); create one if not found."""
-    org = Organization.objects.filter(name__iexact=name).first()
+    """Look up an Organization by name or slug (case-insensitive); create one if not found.
+
+    In dry-run mode the new Organization is returned unsaved — nothing is written.
+    """
+    org = Organization.objects.filter(Q(name__iexact=name) | Q(slug__iexact=name)).first()
     if org:
         return org
     slug = slugify(name)

--- a/dbdb/core/management/commands/import_systems.py
+++ b/dbdb/core/management/commands/import_systems.py
@@ -24,6 +24,10 @@ CSV format:
     Organization field (name or slug; looked up case-insensitively or created):
       developer_orgs
 
+    Organization URL field (applied to the Organization when exactly one developer_org
+    is present and the org has no value for that field yet):
+      linkedin_url
+
   Unknown header names are skipped with a warning.
 
 Additional behaviour:
@@ -73,8 +77,12 @@ _ATTR_OPTION_FIELDS: dict[str, str] = {
 _SYSTEM_M2M_FIELDS  = frozenset({'derived_from', 'embedded', 'inspired_by', 'compatible_with', 'hosted_services'})
 _ARRAY_FIELDS       = frozenset({'former_names'})
 _ORG_FIELDS         = frozenset({'developer_orgs'})
+# URL fields applied to the matched/created Organization (not to SystemVersion).
+# Ignored when more than one developer_org is present in the row.
+_ORG_URL_FIELDS     = frozenset({'linkedin_url'})
 _KNOWN_FIELDS       = (_URL_FIELDS | _COUNTRY_FIELDS | _TEXT_FIELDS | _INT_FIELDS
-                       | _ARRAY_FIELDS | _ORG_FIELDS | frozenset(_ATTR_OPTION_FIELDS) | _SYSTEM_M2M_FIELDS)
+                       | _ARRAY_FIELDS | _ORG_FIELDS | _ORG_URL_FIELDS
+                       | frozenset(_ATTR_OPTION_FIELDS) | _SYSTEM_M2M_FIELDS)
 _OPEN_SOURCE_SLUG  = 'open-source'
 _PROJECT_TYPE_SLUG = 'project-type'
 _URL_TRUNC         = 45
@@ -406,6 +414,21 @@ class Command(DbdbBaseCommand):
         if 'developer_orgs' in field_values:
             dev_org = _get_or_create_org(field_values['developer_orgs'], dry_run=dry_run)
 
+        # Resolve org-level URL fields (e.g. linkedin_url).
+        # Only applied when there is exactly one developer_org and the org does
+        # not already have that URL set.
+        org_count = len([t for t in field_values.get('developer_orgs', '').split(',') if t.strip()])
+        org_url_cites: dict[str, CitationUrl] = {}
+        if org_count == 1 and dev_org is not None:
+            for field in _ORG_URL_FIELDS:
+                if field not in field_values:
+                    continue
+                if getattr(dev_org, f'{field}_id', None) is not None:
+                    continue  # org already has this URL
+                cite = _cite(field_values[field])
+                if cite:
+                    org_url_cites[field] = cite
+
         # Build the result record.
         result: dict = {'name': name, 'slug': slug,
                         'logo': os.path.basename(logo_path) if logo_path else '',
@@ -416,6 +439,8 @@ class Command(DbdbBaseCommand):
         for f in _COUNTRY_FIELDS | _TEXT_FIELDS | _INT_FIELDS:
             result[f] = field_values.get(f, '')
         result['developer_orgs'] = dev_org.name if dev_org else field_values.get('developer_orgs', '')
+        for field, cite in org_url_cites.items():
+            result[field] = _trunc(cite.url)
         for field, opts in attr_opts.items():
             result[field] = ', '.join(o.name for o in opts)
         for field, systems in system_m2m.items():
@@ -474,6 +499,15 @@ class Command(DbdbBaseCommand):
             # developer_orgs.
             if dev_org:
                 sv.developer_orgs.set([dev_org])
+
+            # Apply org-level URL fields (linkedin_url, etc.) to the Organization.
+            if org_url_cites and dev_org and dev_org.pk:
+                update_fields = []
+                for field, cite in org_url_cites.items():
+                    setattr(dev_org, field, cite)
+                    update_fields.append(field)
+                update_fields.append('modified')
+                dev_org.save(update_fields=update_fields)
 
             # Always add "Open Source" if a source repo is present.
             if sv.sourcerepo_url and open_source_opt:

--- a/dbdb/core/migrations/0099_organization_stock_exchange_fk.py
+++ b/dbdb/core/migrations/0099_organization_stock_exchange_fk.py
@@ -1,0 +1,100 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+# Integer values from the old StockExchange.IntegerChoices → AttributeOption slug
+_INT_TO_SLUG = {
+    1: 'nyse',
+    2: 'nasdaq',
+    3: 'lse',
+    4: 'tse',
+    5: 'hkex',
+    6: 'asx',
+    7: 'tsx',
+    8: 'euronext',
+    9: 'other',
+}
+
+# Seed data: (slug, name, url) — mirrors the old StockExchange.url dict
+_STOCK_EXCHANGES = [
+    ('nyse',     'NYSE',     'https://www.nyse.com/quote/XNYS:'),
+    ('nasdaq',   'NASDAQ',   'https://www.nasdaq.com/market-activity/stocks/'),
+    ('lse',      'LSE',      'https://www.londonstockexchange.com'),
+    ('tse',      'TSE',      'https://www.jpx.co.jp/english/'),
+    ('hkex',     'HKEX',     'https://www.hkex.com.hk'),
+    ('asx',      'ASX',      'https://www.asx.com.au'),
+    ('tsx',      'TSX',      'https://www.tsx.com'),
+    ('euronext', 'Euronext', 'https://www.euronext.com'),
+    ('other',    'Other',    ''),
+]
+
+
+def migrate_to_fk(apps, schema_editor):
+    Attribute       = apps.get_model('core', 'Attribute')
+    AttributeOption = apps.get_model('core', 'AttributeOption')
+    Organization    = apps.get_model('core', 'Organization')
+
+    se_attr, _ = Attribute.objects.get_or_create(
+        slug='stock-exchange',
+        defaults={'name': 'Stock Exchange'},
+    )
+    slug_to_option = {}
+    for slug, name, url in _STOCK_EXCHANGES:
+        opt, _ = AttributeOption.objects.update_or_create(
+            attribute=se_attr, slug=slug,
+            defaults={'name': name, 'url': url},
+        )
+        slug_to_option[slug] = opt
+
+    for org in Organization.objects.filter(stock_exchange_int__isnull=False):
+        slug = _INT_TO_SLUG.get(org.stock_exchange_int)
+        if slug:
+            org.stock_exchange = slug_to_option[slug]
+            org.save(update_fields=['stock_exchange'])
+
+
+def reverse_to_int(apps, schema_editor):
+    _SLUG_TO_INT = {v: k for k, v in _INT_TO_SLUG.items()}
+    Organization = apps.get_model('core', 'Organization')
+    for org in Organization.objects.filter(stock_exchange__isnull=False):
+        slug = org.stock_exchange.slug
+        int_val = _SLUG_TO_INT.get(slug)
+        if int_val is not None:
+            org.stock_exchange_int = int_val
+            org.save(update_fields=['stock_exchange_int'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0098_unique_user_email'),
+    ]
+
+    operations = [
+        # 1. Preserve old integer data under a temporary name
+        migrations.RenameField(
+            model_name='organization',
+            old_name='stock_exchange',
+            new_name='stock_exchange_int',
+        ),
+        # 2. Add the new FK column (nullable)
+        migrations.AddField(
+            model_name='organization',
+            name='stock_exchange',
+            field=models.ForeignKey(
+                blank=True, null=True,
+                limit_choices_to={'attribute__slug': 'stock-exchange'},
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='org_stock_exchanges',
+                to='core.attributeoption',
+                verbose_name='Stock Exchange',
+            ),
+        ),
+        # 3. Populate FK from old integer values
+        migrations.RunPython(migrate_to_fk, reverse_to_int),
+        # 4. Drop the old integer column
+        migrations.RemoveField(
+            model_name='organization',
+            name='stock_exchange_int',
+        ),
+    ]

--- a/dbdb/core/models.py
+++ b/dbdb/core/models.py
@@ -306,30 +306,6 @@ class OrgType(models.IntegerChoices):
         }.get(self.value, '')
 
 
-class StockExchange(models.IntegerChoices):
-    NYSE     = 1, 'NYSE'
-    NASDAQ   = 2, 'NASDAQ'
-    LSE      = 3, 'LSE'
-    TSE      = 4, 'TSE'
-    HKEX     = 5, 'HKEX'
-    ASX      = 6, 'ASX'
-    TSX      = 7, 'TSX'
-    EURONEXT = 8, 'Euronext'
-    OTHER    = 9, 'Other'
-
-    @property
-    def url(self):
-        """URLs to go directly to the stock symbol on the exchange"""
-        return {
-            1: 'https://www.nyse.com/quote/XNYS:',
-            2: 'https://www.nasdaq.com/market-activity/stocks/',
-            3: 'https://www.londonstockexchange.com',
-            4: 'https://www.jpx.co.jp/english/',
-            5: 'https://www.hkex.com.hk',
-            6: 'https://www.asx.com.au',
-            7: 'https://www.tsx.com',
-            8: 'https://www.euronext.com',
-        }.get(self.value, '')
 
 
 class Organization(LogoMixin, models.Model):
@@ -362,8 +338,11 @@ class Organization(LogoMixin, models.Model):
         choices=OrgType.choices, null=True, blank=True,
         verbose_name='Organization Type')
 
-    stock_exchange = models.IntegerField(
-        choices=StockExchange.choices, null=True, blank=True,
+    stock_exchange = models.ForeignKey(
+        'AttributeOption', models.SET_NULL,
+        null=True, blank=True,
+        limit_choices_to={'attribute__slug': 'stock-exchange'},
+        related_name='org_stock_exchanges',
         verbose_name='Stock Exchange')
 
     stock_symbol = models.CharField(
@@ -399,10 +378,6 @@ class Organization(LogoMixin, models.Model):
     @property
     def org_type_obj(self):
         return OrgType(self.org_type) if self.org_type is not None else None
-
-    @property
-    def stock_exchange_obj(self):
-        return StockExchange(self.stock_exchange) if self.stock_exchange is not None else None
 
     @property
     def linkedin_handle(self):

--- a/dbdb/core/tests/test_repository.py
+++ b/dbdb/core/tests/test_repository.py
@@ -1,0 +1,231 @@
+import datetime
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from dbdb.core.models import (
+    AttributeOption, CitationUrl, RepositoryInfo, RepositorySnapshot,
+    System, SystemVersion,
+)
+from dbdb.core.utils.repositories.base import SnapshotData
+from dbdb.core.utils.repository import check_abandoned, check_resurrection
+from dbdb.core.utils.versions import clone_system_version, finalize_new_version
+
+User = get_user_model()
+
+INACTIVITY_DAYS = 365
+
+
+# ==============================================
+# CheckAbandonedTestCase
+# ==============================================
+@override_settings(DBDB_BOT_ACCOUNT='admin')
+class CheckAbandonedTestCase(TestCase):
+    fixtures = ['adminuser.json', 'core_features.json', 'core_attributes.json', 'core_system.json']
+
+    def setUp(self):
+        self.system = System.objects.first()
+        self.sv = SystemVersion.objects.get(system=self.system, is_current=True)
+        self.abandoned_tag = AttributeOption.objects.get(attribute__slug='tag', slug='abandoned')
+
+    def _make_repo(self, enabled=True):
+        citation = CitationUrl.objects.create(url='https://github.com/dbdb-test/testrepo')
+        repo_info = RepositoryInfo.objects.create(sourcerepo_url=citation, enabled=enabled)
+        self.sv.sourcerepo_url = citation
+        self.sv.save(update_fields=['sourcerepo_url'])
+        return citation, repo_info
+
+    def _make_snapshot(self, repo_info, **kwargs):
+        snapshot = RepositorySnapshot.objects.create(repo=repo_info, **kwargs)
+        repo_info.current = snapshot
+        repo_info.save(update_fields=['current', 'modified'])
+        return snapshot
+
+    def test_raises_when_no_sourcerepo_url(self):
+        self.sv.sourcerepo_url = None
+        self.sv.save(update_fields=['sourcerepo_url'])
+        with self.assertRaises(ValueError):
+            check_abandoned(self.system, inactivity_days=INACTIVITY_DAYS)
+
+    def test_raises_when_no_repo_info(self):
+        citation = CitationUrl.objects.create(url='https://github.com/dbdb-test/norepo')
+        self.sv.sourcerepo_url = citation
+        self.sv.save(update_fields=['sourcerepo_url'])
+        with self.assertRaises(ValueError):
+            check_abandoned(self.system, inactivity_days=INACTIVITY_DAYS)
+
+    def test_returns_false_with_no_snapshots(self):
+        self._make_repo()
+        self.assertFalse(check_abandoned(self.system, inactivity_days=INACTIVITY_DAYS))
+
+    def test_returns_false_with_one_snapshot(self):
+        _, repo_info = self._make_repo()
+        old_ts = timezone.now() - datetime.timedelta(days=INACTIVITY_DAYS + 10)
+        self._make_snapshot(repo_info, commit_count=100, merged_pr_count=10,
+                            last_commit_timestamp=old_ts)
+        self.assertFalse(check_abandoned(self.system, inactivity_days=INACTIVITY_DAYS))
+
+    def test_returns_false_when_commit_count_differs(self):
+        _, repo_info = self._make_repo()
+        old_ts = timezone.now() - datetime.timedelta(days=INACTIVITY_DAYS + 10)
+        self._make_snapshot(repo_info, commit_count=100, merged_pr_count=10,
+                            last_commit_timestamp=old_ts)
+        self._make_snapshot(repo_info, commit_count=101, merged_pr_count=10,
+                            last_commit_timestamp=old_ts)
+        self.assertFalse(check_abandoned(self.system, inactivity_days=INACTIVITY_DAYS))
+
+    def test_returns_false_when_last_commit_recent(self):
+        _, repo_info = self._make_repo()
+        old_ts = timezone.now() - datetime.timedelta(days=INACTIVITY_DAYS + 10)
+        self._make_snapshot(repo_info, commit_count=100, merged_pr_count=10,
+                            last_commit_timestamp=old_ts)
+        self._make_snapshot(repo_info, commit_count=100, merged_pr_count=10,
+                            last_commit_timestamp=timezone.now() - datetime.timedelta(days=10))
+        self.assertFalse(check_abandoned(self.system, inactivity_days=INACTIVITY_DAYS))
+
+    def test_marks_abandoned_when_stale_and_inactive(self):
+        _, repo_info = self._make_repo()
+        old_ts = timezone.now() - datetime.timedelta(days=INACTIVITY_DAYS + 10)
+        self._make_snapshot(repo_info, commit_count=100, merged_pr_count=10,
+                            last_commit_timestamp=old_ts)
+        self._make_snapshot(repo_info, commit_count=100, merged_pr_count=10,
+                            last_commit_timestamp=old_ts)
+        self.assertTrue(check_abandoned(self.system, inactivity_days=INACTIVITY_DAYS))
+
+        new_sv = SystemVersion.objects.get(system=self.system, is_current=True)
+        self.assertIn(self.abandoned_tag, new_sv.tags.all())
+        self.assertIsNotNone(new_sv.end_year)
+
+        repo_info.refresh_from_db()
+        self.assertFalse(repo_info.enabled)
+
+    def test_marks_abandoned_immediately_on_archival(self):
+        _, repo_info = self._make_repo()
+        archival_ts = timezone.now() - datetime.timedelta(days=30)
+        self._make_snapshot(repo_info, archival_timestamp=archival_ts,
+                            commit_count=100, merged_pr_count=10)
+        self.assertTrue(check_abandoned(self.system, inactivity_days=INACTIVITY_DAYS))
+
+        new_sv = SystemVersion.objects.get(system=self.system, is_current=True)
+        self.assertIn(self.abandoned_tag, new_sv.tags.all())
+
+
+# ==============================================
+# CheckResurrectionTestCase
+# ==============================================
+@override_settings(DBDB_BOT_ACCOUNT='admin')
+class CheckResurrectionTestCase(TestCase):
+    fixtures = ['adminuser.json', 'core_features.json', 'core_attributes.json', 'core_system.json']
+
+    ABANDONED_DAYS_AGO = 60
+
+    def setUp(self):
+        self.system = System.objects.first()
+        self.sv = SystemVersion.objects.get(system=self.system, is_current=True)
+        self.abandoned_tag = AttributeOption.objects.get(attribute__slug='tag', slug='abandoned')
+
+        self.citation = CitationUrl.objects.create(url='https://github.com/dbdb-test/testrepo')
+        self.repo_info = RepositoryInfo.objects.create(
+            sourcerepo_url=self.citation, enabled=False
+        )
+        self.sv.sourcerepo_url = self.citation
+        self.sv.tags.add(self.abandoned_tag)
+        self.sv.save(update_fields=['sourcerepo_url'])
+
+        # Set current_version.created to a known past time so the activity
+        # threshold is deterministic (auto_now_add cannot be set at creation time).
+        self.abandoned_since = timezone.now() - datetime.timedelta(days=self.ABANDONED_DAYS_AGO)
+        SystemVersion.objects.filter(pk=self.sv.pk).update(created=self.abandoned_since)
+        self.sv.refresh_from_db()
+
+    def _snap(self, **kwargs):
+        return SnapshotData(**kwargs)
+
+    def test_returns_false_when_not_tagged_abandoned(self):
+        self.sv.tags.remove(self.abandoned_tag)
+        with patch('dbdb.core.utils.repository.fetch_snapshot_data') as mock_fetch:
+            mock_fetch.return_value = self._snap()
+            self.assertFalse(check_resurrection(self.system))
+        self.assertEqual(self.system.versions.filter(approved=False).count(), 0)
+
+    def test_returns_false_when_no_activity(self):
+        old_ts = self.abandoned_since - datetime.timedelta(days=10)
+        with patch('dbdb.core.utils.repository.fetch_snapshot_data') as mock_fetch:
+            mock_fetch.return_value = self._snap(
+                last_commit_timestamp=old_ts,
+                last_pr_closed_at=old_ts,
+                last_issue_closed_at=old_ts,
+            )
+            self.assertFalse(check_resurrection(self.system))
+        self.assertEqual(self.system.versions.filter(approved=False).count(), 0)
+
+    def test_creates_pending_on_new_commit(self):
+        recent_ts = self.abandoned_since + datetime.timedelta(days=10)
+        with patch('dbdb.core.utils.repository.fetch_snapshot_data') as mock_fetch:
+            mock_fetch.return_value = self._snap(last_commit_timestamp=recent_ts, commit_count=101)
+            self.assertTrue(check_resurrection(self.system))
+
+        pending = self.system.pending_version()
+        self.assertIsNotNone(pending)
+        self.assertFalse(pending.approved)
+        self.assertIsNone(pending.end_year)
+        self.assertNotIn(self.abandoned_tag, pending.tags.all())
+
+    def test_creates_pending_on_closed_pr(self):
+        recent_ts = self.abandoned_since + datetime.timedelta(days=5)
+        with patch('dbdb.core.utils.repository.fetch_snapshot_data') as mock_fetch:
+            mock_fetch.return_value = self._snap(last_pr_closed_at=recent_ts, merged_pr_count=50)
+            self.assertTrue(check_resurrection(self.system))
+        self.assertIsNotNone(self.system.pending_version())
+
+    def test_creates_pending_on_closed_issue(self):
+        recent_ts = self.abandoned_since + datetime.timedelta(days=5)
+        with patch('dbdb.core.utils.repository.fetch_snapshot_data') as mock_fetch:
+            mock_fetch.return_value = self._snap(last_issue_closed_at=recent_ts, closed_issue_count=1)
+            self.assertTrue(check_resurrection(self.system))
+        self.assertIsNotNone(self.system.pending_version())
+
+    def test_modifies_existing_pending_version(self):
+        admin = User.objects.get(username='admin')
+        existing_pending = clone_system_version(
+            self.sv, creator=admin, comment="Pre-existing edit", approved=False
+        )
+        finalize_new_version(existing_pending, old_logo=self.sv.logo)
+
+        recent_ts = self.abandoned_since + datetime.timedelta(days=10)
+        with patch('dbdb.core.utils.repository.fetch_snapshot_data') as mock_fetch:
+            mock_fetch.return_value = self._snap(last_commit_timestamp=recent_ts, commit_count=200)
+            self.assertTrue(check_resurrection(self.system))
+
+        self.assertEqual(self.system.versions.filter(approved=False).count(), 1)
+
+        existing_pending.refresh_from_db()
+        self.assertIsNone(existing_pending.end_year)
+        self.assertNotIn(self.abandoned_tag, existing_pending.tags.all())
+        self.assertIn("dormant", existing_pending.history)
+
+    def test_does_not_reenable_repo_info(self):
+        recent_ts = self.abandoned_since + datetime.timedelta(days=10)
+        with patch('dbdb.core.utils.repository.fetch_snapshot_data') as mock_fetch:
+            mock_fetch.return_value = self._snap(last_commit_timestamp=recent_ts, commit_count=101)
+            check_resurrection(self.system)
+        self.repo_info.refresh_from_db()
+        self.assertFalse(self.repo_info.enabled)
+
+    def test_history_note_appended(self):
+        recent_ts = self.abandoned_since + datetime.timedelta(days=10)
+        with patch('dbdb.core.utils.repository.fetch_snapshot_data') as mock_fetch:
+            mock_fetch.return_value = self._snap(last_commit_timestamp=recent_ts, commit_count=101)
+            check_resurrection(self.system)
+        pending = self.system.pending_version()
+        self.assertIn("dormant", pending.history)
+        self.assertIn(str(timezone.now().year), pending.history)
+
+    def test_pending_version_is_not_approved(self):
+        recent_ts = self.abandoned_since + datetime.timedelta(days=10)
+        with patch('dbdb.core.utils.repository.fetch_snapshot_data') as mock_fetch:
+            mock_fetch.return_value = self._snap(last_commit_timestamp=recent_ts, commit_count=101)
+            check_resurrection(self.system)
+        self.assertFalse(self.system.pending_version().approved)

--- a/dbdb/core/utils/enrichment/schema.py
+++ b/dbdb/core/utils/enrichment/schema.py
@@ -239,11 +239,11 @@ _ORG_CITATIONS_SCHEMA = {
 
 def build_org_enrichment_tool(missing_fields: list[str]) -> dict:
     """Return a save_org_enrichment tool schema limited to *missing_fields*."""
-    from dbdb.core.models import OrgType, StockExchange
+    from dbdb.core.models import AttributeOption, OrgType
 
     _enums = {
-        "org_type":      [label for _, label in OrgType.choices],
-        "stock_exchange": [label for _, label in StockExchange.choices],
+        "org_type":       [label for _, label in OrgType.choices],
+        "stock_exchange": list(AttributeOption.objects.filter(attribute__slug='stock-exchange').values_list('name', flat=True)),
     }
 
     properties = {}

--- a/dbdb/core/utils/repository.py
+++ b/dbdb/core/utils/repository.py
@@ -213,6 +213,114 @@ def check_abandoned(system:System, *, inactivity_days: int = 1095) -> bool:
     return True
 
 
+def check_resurrection(system: System) -> bool:
+    """
+    Check whether a system tagged 'Abandoned' has shown signs of recent activity.
+
+    Fetches a fresh snapshot regardless of RepositoryInfo.enabled. If any activity
+    (new commit, closed PR, or closed issue) is detected after the abandonment date,
+    creates a pending SystemVersion for admin review that removes the Abandoned tag
+    and clears end_year. If a pending version already exists it is modified in place.
+
+    Returns True if a resurrection was flagged, False otherwise.
+
+    Raises:
+        ValueError: The system has no sourcerepo_url.
+    """
+    from dbdb.core.models import AttributeOption, RepositoryInfo, RepositorySnapshot
+
+    current = SystemVersion.objects.get(system=system, is_current=True)
+
+    if not current.sourcerepo_url_id:
+        raise ValueError(f"System '{system.slug}' has no sourcerepo_url")
+
+    citation = current.sourcerepo_url
+
+    # Do NOT gate on enabled — abandoned repos have enabled=False by design
+    repo_info, _ = RepositoryInfo.objects.get_or_create(sourcerepo_url=citation)
+
+    abandoned_tag = AttributeOption.objects.get(attribute__slug='tag', slug='abandoned')
+    if not current.tags.filter(pk=abandoned_tag.pk).exists():
+        return False
+
+    snap = fetch_snapshot_data(citation)
+
+    if snap.errors and not snap.has_data:
+        computed_status = RepositorySnapshot.Status.FAILED
+    elif snap.errors:
+        computed_status = RepositorySnapshot.Status.ERROR
+    else:
+        computed_status = RepositorySnapshot.Status.VALID
+
+    snapshot = RepositorySnapshot.objects.create(
+        repo=repo_info,
+        status=computed_status,
+        **snap.to_model_kwargs(),
+    )
+    repo_info.current = snapshot
+    repo_info.last_snapshot = timezone.now()
+    repo_info.save(update_fields=['current', 'last_snapshot', 'modified'])
+
+    abandoned_since = current.created
+
+    def _after(ts):
+        return ts is not None and ts > abandoned_since
+
+    if not (_after(snapshot.last_commit_timestamp) or
+            _after(snapshot.last_pr_closed_at) or
+            _after(snapshot.last_issue_closed_at)):
+        return False
+
+    bot_user = get_user_model().objects.get(username=settings.DBDB_BOT_ACCOUNT)
+    pending = system.pending_version()
+    _mark_resurrected(current, snapshot, abandoned_since, creator=bot_user, pending=pending)
+    return True
+
+
+def _mark_resurrected(
+    current_version: SystemVersion,
+    snapshot: RepositorySnapshot,
+    abandoned_since,
+    creator,
+    pending=None,
+):
+    """Apply resurrection changes to an existing pending version or create a new one."""
+    from dbdb.core.models import AttributeOption
+
+    abandoned_tag = AttributeOption.objects.get(attribute__slug='tag', slug='abandoned')
+
+    now = timezone.now()
+    dormant_months = (now.year - abandoned_since.year) * 12 + (now.month - abandoned_since.month)
+
+    history_note = (
+        f"This project was dormant for approximately {dormant_months} months but has "
+        f"shown signs of activity as of {now.strftime('%B %Y')}."
+    )
+    comment = (
+        f"Automatically flagged for resurrection: repository activity detected after "
+        f"{dormant_months} months of inactivity."
+    )
+
+    if pending is None:
+        new_version = clone_system_version(
+            current_version,
+            creator=creator,
+            comment=comment,
+            approved=False,
+            end_year=None,
+        )
+        new_version.tags.remove(abandoned_tag)
+        new_version.history = (current_version.history + "\n\n" + history_note).strip()
+        new_version.save(update_fields=['history'])
+        finalize_new_version(new_version, old_logo=current_version.logo)
+    else:
+        pending.end_year = None
+        pending.comment = comment
+        pending.tags.remove(abandoned_tag)
+        pending.history = (pending.history + "\n\n" + history_note).strip()
+        pending.save(update_fields=['end_year', 'comment', 'history'])
+
+
 def _mark_abandoned(current_version:SystemVersion, repo_info:RepositoryInfo, snapshot:RepositorySnapshot):
     """Clone current_version, apply the abandoned tag, and disable scanning."""
     from dbdb.core.models import AttributeOption

--- a/scripts/resurect_repos.sh
+++ b/scripts/resurect_repos.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Check if any abandoned repo has come back to life! Run this once a month!
+# This has to run on a machine that has storage space for all the collected repos.
+
+LOCKFILE="/run/lock/collect_repos.lock"
+exec 9>"$LOCKFILE"
+flock --nonblock 9 || { echo "collect_repos.sh: already running, exiting." >&2; exit 1; }
+
+uv run ./manage.py collect_repo_info --debug \
+  --check-resurrection \
+  --ignore-last-checked=14 \
+  --sleep=180 \
+  github.com

--- a/templates/core/organization_view.html
+++ b/templates/core/organization_view.html
@@ -84,10 +84,10 @@
             <dd class="font-monospace">
                 {% if org.stock_delisted %}<s>{% endif %}
                 {% if org.stock_exchange %}
-                    {% if org.stock_exchange_obj.url and not org.stock_delisted %}
-                        <a href="{{ org.stock_exchange_obj.url }}{{ org.stock_symbol }}" target="_blank" title="View {{ org.name }} on {{ org.get_stock_exchange_display }}">{{ org.get_stock_exchange_display }}:{{ org.stock_symbol }}</a>
+                    {% if org.stock_exchange.url and not org.stock_delisted %}
+                        <a href="{{ org.stock_exchange.url }}{{ org.stock_symbol }}" target="_blank" title="View {{ org.name }} on {{ org.stock_exchange.name }}">{{ org.stock_exchange.name }}:{{ org.stock_symbol }}</a>
                     {% else %}
-                        {{ org.get_stock_exchange_display }}:{{ org.stock_symbol }}
+                        {{ org.stock_exchange.name }}:{{ org.stock_symbol }}
                     {% endif %}
                 {% else %}
                     {{ org.stock_symbol }}


### PR DESCRIPTION
Scans systems tagged "Abandoned" for signs of resumed activity (new commit, closed PR, or closed issue after the abandonment date). When activity is detected, creates a pending SystemVersion that removes the Abandoned tag, clears end_year, and appends a history note recording the dormancy period and resurrection month. If a pending version already exists it is modified in place.

RepositoryInfo.enabled is intentionally left False — the admin re-enables it when approving the resurrection version. The resurrection check bypasses the enabled gate so abandoned repos receive a fresh snapshot on each run.


Claude-Session: https://claude.ai/code/session_01RsQ3awvsgsWYFCFsnY3j4w