### PR TITLE
Support newer OpenAI reasoning models and add --force-field flag

### DIFF
--- a/dbdb/core/management/base.py
+++ b/dbdb/core/management/base.py
@@ -59,6 +59,9 @@ class EnricherBaseCommand(DbdbBaseCommand):
                             help='Re-fetch a URL only if cached content is older than N days (default: 7)')
         parser.add_argument('--skip-field', action='append', default=[], metavar='FIELD',
                             help='Exclude a field from enrichment (may be repeated)')
+        parser.add_argument('--force-field', action='append', default=[], metavar='FIELD',
+                            help='Include FIELD in the enrichment request even if already '
+                                 'populated, to try to get a better value (may be repeated)')
         parser.add_argument('--skip-spamcheck', action='store_true',
                             help='Disable spam checking when retrieving URLs')
         parser.add_argument('--skip-errors', action='store_true',

--- a/dbdb/core/management/commands/enrich_organization.py
+++ b/dbdb/core/management/commands/enrich_organization.py
@@ -86,10 +86,13 @@ def _query_orgs_missing_field(field: str):
     return Organization.objects.filter(Q(**{f'{field}__isnull': True}) | Q(**{field: ''}))
 
 
-def _get_missing_org_fields(org: Organization, requested: list[str] | None) -> list[str]:
-    if requested:
-        return list(requested)
-    return [f for f in ORG_ALL_FIELDS if _is_org_field_empty(org, f)]
+def _get_missing_org_fields(org: Organization, requested: list[str] | None,
+                            force: set[str] | None = None) -> list[str]:
+    fields = list(requested) if requested else [f for f in ORG_ALL_FIELDS if _is_org_field_empty(org, f)]
+    for f in (force or ()):
+        if f not in fields:
+            fields.append(f)
+    return fields
 
 
 def _generate_unique_org_slug(name: str, exclude_pk: int | None = None) -> str:
@@ -287,8 +290,9 @@ class Command(EnricherBaseCommand):
 
         # --- 2. Identify missing fields ---
         skip_fields = set(options['skip_field'])
+        force_fields = set(options.get('force_field') or [])
         missing_fields = [
-            f for f in _get_missing_org_fields(org, requested_fields)
+            f for f in _get_missing_org_fields(org, requested_fields, force=force_fields)
             if f not in skip_fields
         ]
         if not missing_fields:

--- a/dbdb/core/management/commands/enrich_system.py
+++ b/dbdb/core/management/commands/enrich_system.py
@@ -80,12 +80,18 @@ def _is_field_empty(version: SystemVersion, field: str) -> bool:
     return str(val).strip() == ''
 
 
-def _get_missing_fields(version: SystemVersion, requested: list[str] | None) -> list[str]:
-    """Return the subset of requested fields (or all) that are empty."""
+def _get_missing_fields(version: SystemVersion, requested: list[str] | None,
+                        force: set[str] | None = None) -> list[str]:
+    """Return the subset of requested fields (or all) that are empty, plus any forced fields."""
     if requested:
-        return list(requested)
-    all_fields = list(SIMPLE_TEXT_FIELDS) + list(INT_FIELDS) + list(URL_FK_FIELDS) + list(M2M_ATTR_FIELDS)
-    return [f for f in all_fields if _is_field_empty(version, f)]
+        fields = list(requested)
+    else:
+        all_fields = list(SIMPLE_TEXT_FIELDS) + list(INT_FIELDS) + list(URL_FK_FIELDS) + list(M2M_ATTR_FIELDS)
+        fields = [f for f in all_fields if _is_field_empty(version, f)]
+    for f in (force or ()):
+        if f not in fields:
+            fields.append(f)
+    return fields
 
 
 
@@ -430,7 +436,11 @@ class Command(EnricherBaseCommand):
 
         # --- 2. Identify missing fields ---
         skip_fields = set(options['skip_field'])
-        missing_fields = [f for f in _get_missing_fields(current, requested_fields) if f not in skip_fields]
+        force_fields = set(options.get('force_field') or [])
+        missing_fields = [
+            f for f in _get_missing_fields(current, requested_fields, force=force_fields)
+            if f not in skip_fields
+        ]
         missing_features = [f for f in _get_missing_features(current) if f.slug not in skip_fields]
 
         if not missing_fields and not missing_features:

--- a/dbdb/core/tests/test_enrichment.py
+++ b/dbdb/core/tests/test_enrichment.py
@@ -44,6 +44,7 @@ def _options(**overrides):
         'enricher': 'mock',
         'model': None,
         'skip_field': [],
+        'force_field': [],
         'fields': None,
         'per_feature': False,
         'include_urls': False,

--- a/dbdb/core/utils/enrichment/chatgpt.py
+++ b/dbdb/core/utils/enrichment/chatgpt.py
@@ -1,6 +1,7 @@
 """ChatGPTEnricher — OpenAI function-calling backend."""
 import json
 import logging
+import re
 
 from django.conf import settings
 
@@ -8,6 +9,12 @@ from .base import BaseEnricher
 from .schema import get_system_prompt
 
 LOG = logging.getLogger(__name__)
+
+
+def _is_reasoning_model(model: str) -> bool:
+    """OpenAI reasoning-family models (gpt-5.x, o-series) reject function
+    tools combined with a non-'none' reasoning_effort on /v1/chat/completions."""
+    return bool(re.match(r'^(o\d|gpt-5)', model))
 
 
 class ChatGPTEnricher(BaseEnricher):
@@ -32,7 +39,7 @@ class ChatGPTEnricher(BaseEnricher):
             print(f"[USER]\n{user_prompt}")
             return {}
         client = openai.OpenAI(api_key=settings.OPENAI_API_KEY)
-        response = client.chat.completions.create(
+        kwargs = dict(
             model=model,
             messages=[
                 {"role": "system", "content": get_system_prompt(fn_name, name=self._name, organization=self._organization)},
@@ -48,6 +55,9 @@ class ChatGPTEnricher(BaseEnricher):
             }],
             tool_choice={"type": "function", "function": {"name": fn_name}},
         )
+        if _is_reasoning_model(model):
+            kwargs["reasoning_effort"] = "none"
+        response = client.chat.completions.create(**kwargs)
         for choice in response.choices:
             for tc in (choice.message.tool_calls or []):
                 if tc.function.name == fn_name:


### PR DESCRIPTION
ChatGPTEnricher now sets reasoning_effort='none' for gpt-5.x/o-series models when calling with function tools, since /v1/chat/completions rejects tools + reasoning_effort together for those models. Also add a repeatable --force-field flag to enrich_system/enrich_organization so an already-populated field can be re-sent to the LLM for a better value.